### PR TITLE
tokio: limit number of threads and set names

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -42,7 +42,7 @@ use std::{println as info, println as warn};
 macro_rules! info_with_replica {
     ($replica_id:expr, $($arg:tt)*) => {{
         let parts: Vec<&str> = $replica_id.splitn(2, ':').collect();
-        let formatted_message = if parts.len() == 2 {
+        if parts.len() == 2 {
             // If there are two parts, use the replica name
             info!("[Replica {}] {}", parts[0], format!($($arg)*))
         } else {


### PR DESCRIPTION
Tokio by default creates the runtime with threads equal to the number of CPUs. On beefy GPU boxes there may be hundreds of cores leading to hundreds of useless threads that make it harder to debug issues via `lldb`.

This also sets the thread names so it's easier to understand what pools are for what.

Test plan:

```
$ torchft_lighthouse
$ lldb -p 1234
> thread backtrace all
```

```
  thread #243, name = 'torchft-lighths', stop reason = signal SIGSTOP
    frame #0: 0x00007fd7fcd0792d libc.so.6`syscall + 29
    frame #1: 0x00007fd65a51e0a9 _torchft.cpython-312-x86_64-linux-gnu.so`parking_lot::condvar::Condvar::wait_until_internal::ha421dfa1f35f6d78 + 649
    frame #2: 0x00007fd65a50fdee _torchft.cpython-312-x86_64-linux-gnu.so`tokio::runtime::scheduler::multi_thread::park::Parker::park::h1064fe7e072bea0b + 222
    frame #3: 0x00007fd65a5166da _torchft.cpython-312-x86_64-linux-gnu.so`tokio::runtime::scheduler::multi_thread::worker::Context::park_timeout::hb6e439a80eb82fbc + 154
    frame #4: 0x00007fd65a515dbf _torchft.cpython-312-x86_64-linux-gnu.so`tokio::runtime::scheduler::multi_thread::worker::Context::run::h925c9d2cbee36e7e + 2879
    frame #5: 0x00007fd65a502fc4 _torchft.cpython-312-x86_64-linux-gnu.so`tokio::runtime::context::runtime::enter_runtime::h15ac70dde2453af5 + 692
    frame #6: 0x00007fd65a5151fa _torchft.cpython-312-x86_64-linux-gnu.so`tokio::runtime::scheduler::multi_thread::worker::run::h6967ec6caf4789c9 + 138
    frame #7: 0x00007fd65a4fa357 _torchft.cpython-312-x86_64-linux-gnu.so`_$LT$tokio..runtime..blocking..task..BlockingTask$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$::poll::he2363864a5567ead + 135
    frame #8: 0x00007fd65a4fddd3 _torchft.cpython-312-x86_64-linux-gnu.so`tokio::runtime::task::core::Core$LT$T$C$S$GT$::poll::hdbdd87c38a1334ff + 147
    frame #9: 0x00007fd65a4f3164 _torchft.cpython-312-x86_64-linux-gnu.so`tokio::runtime::task::harness::Harness$LT$T$C$S$GT$::poll::h635b9aa31f062af8 + 180
    frame #10: 0x00007fd65a4f63ff _torchft.cpython-312-x86_64-linux-gnu.so`tokio::runtime::blocking::pool::Inner::run::h40998686924d7eab + 239
    frame #11: 0x00007fd65a4f844e _torchft.cpython-312-x86_64-linux-gnu.so`std::sys::backtrace::__rust_begin_short_backtrace::h71277f9d3c6edc88 + 206
    frame #12: 0x00007fd65a4f8bc2 _torchft.cpython-312-x86_64-linux-gnu.so`core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h0987e2e9d3ea45b5 + 162
    frame #13: 0x00007fd65a54b52b _torchft.cpython-312-x86_64-linux-gnu.so`std::sys::pal::unix::thread::Thread::new::thread_start::hcdbd1049068002f4 + 43
    frame #14: 0x00007fd7fcc8a3b2 libc.so.6`start_thread + 722
    frame #15: 0x00007fd7fcd0f430 libc.so.6`__clone3 + 48
```