### PR TITLE
Added proactive heartbeat timeout failure propagation (#164) (#188)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ slog-stdlog = "4.1.1"
 stderrlog = "0.6.0"
 structopt = "0.3.26"
 tokio = {version = "1.40.0", features = ["full", "test-util", "tracing", "macros", "rt-multi-thread"] }
+tokio-stream = {version = "0.1.14", features = ["sync"]}
 tonic = "0.12.2"
+futures-core = "0.3"
 
 [build-dependencies]
 tonic-build = "0.12.2"

--- a/README.md
+++ b/README.md
@@ -246,6 +246,38 @@ CUDA_VISIBLE_DEVICES=1 TORCHFT_LIGHTHOUSE=http://localhost:29510 torchrun --mast
 
 By observing the outputs from both shells, you should observe process group reconfiguration and live checkpoint recovery.
 
+### Proactive Failure Recovery Mode (Experimental)
+
+You can experiment with proactive failure recovery mode by:
+
+```sh
+export TORCHFT_PROACTIVE_RECOVERY=1
+```
+
+With this enabled, the manager will listen to the Lighthouse server for heartbeat failures of other replica groups and break from a hanging allreduce.
+
+You can test this out by running `train_ddp_proactive.py`
+
+On shell 1 (one replica groups starts initial training):
+```sh
+export REPLICA_GROUP_ID=0
+export NUM_REPLICA_GROUPS=2
+export TORCHFT_PROACTIVE_RECOVERY=1
+
+CUDA_VISIBLE_DEVICES=0 TORCHFT_LIGHTHOUSE=http://localhost:29510 torchrun --master_port=29600 --nnodes=1 --nproc_per_node=1 -- train_ddp_proactive.py
+```
+
+On shell 2 (a second replica group joins):
+```sh
+export REPLICA_GROUP_ID=1
+export NUM_REPLICA_GROUPS=2
+export TORCHFT_PROACTIVE_RECOVERY=1
+
+CUDA_VISIBLE_DEVICES=1 TORCHFT_LIGHTHOUSE=http://localhost:29510 torchrun --master_port=29601 --nnodes=1 --nproc_per_node=1 -- train_ddp_proactive.py
+```
+
+You should observe that the process with replica group id 1 will exit early, and the process with replica group id 0 will quickly resume training. If the same script is ran with after setting `export TORCHFT_PROACTIVE_RECOVERY=0`, you should observe that the process with replica group id 1 will hang for dozens of seconds before continuing.
+
 ### Example Parameter Server
 
 torchft has a fault tolerant parameter server implementation built on it's

--- a/proto/torchft.proto
+++ b/proto/torchft.proto
@@ -67,9 +67,17 @@ message LighthouseHeartbeatRequest {
 
 message LighthouseHeartbeatResponse {}
 
+message SubscribeFailuresRequest {}
+
+message FailureNotification {
+    string replica_id = 1;
+    string error_message = 2;
+}
+
 service LighthouseService {
     rpc Quorum (LighthouseQuorumRequest) returns (LighthouseQuorumResponse);
     rpc Heartbeat (LighthouseHeartbeatRequest) returns (LighthouseHeartbeatResponse);
+    rpc SubscribeFailures (SubscribeFailuresRequest) returns (stream FailureNotification);
 }
 
 message ManagerQuorumRequest {
@@ -126,3 +134,9 @@ service ManagerService {
     rpc ShouldCommit(ShouldCommitRequest) returns (ShouldCommitResponse);
     rpc Kill(KillRequest) returns (KillResponse);
 }
+
+message LighthouseClientRequest {
+    string replica_id = 1;
+}
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod timeout;
 use anyhow::Result;
 use atty::Stream;
 use core::time::Duration;
-use pyo3::exceptions::{PyRuntimeError, PyTimeoutError};
+use pyo3::exceptions::{PyRuntimeError, PyStopIteration, PyTimeoutError};
 use std::cmp;
 use std::env;
 use std::sync::Arc;
@@ -21,6 +21,7 @@ use std::thread::available_parallelism;
 use structopt::StructOpt;
 use tokio::runtime::Runtime;
 use tokio::task::JoinHandle;
+use tokio_stream::StreamExt;
 use tonic::transport::Channel;
 use tonic::Status;
 
@@ -35,11 +36,13 @@ pub mod torchftpb {
 use crate::torchftpb::lighthouse_service_client::LighthouseServiceClient;
 use crate::torchftpb::manager_service_client::ManagerServiceClient;
 use crate::torchftpb::{
-    CheckpointMetadataRequest, LighthouseHeartbeatRequest, LighthouseQuorumRequest,
-    ManagerQuorumRequest, ShouldCommitRequest,
+    CheckpointMetadataRequest, FailureNotification as ProtoFailureNotification,
+    LighthouseHeartbeatRequest, LighthouseQuorumRequest, ManagerQuorumRequest, ShouldCommitRequest,
+    SubscribeFailuresRequest,
 };
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
+use pyo3::{PyRef, PyRefMut};
 
 // Get the number of threads to use for the tokio runtime
 fn num_threads() -> usize {
@@ -290,6 +293,45 @@ struct QuorumResult {
     heal: bool,
 }
 
+#[pyclass(unsendable)]
+struct FailureStream {
+    runtime: Arc<Runtime>,
+    stream: tonic::Streaming<ProtoFailureNotification>,
+    timeout: Duration,
+}
+
+#[pymethods]
+impl FailureStream {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<FailureNotification> {
+        let runtime = slf.runtime.clone();
+        let timeout = slf.timeout;
+        // borrow stream mutably for the whole async block
+        let fut = async { tokio::time::timeout(timeout, slf.stream.next()).await };
+
+        match runtime.block_on(fut) {
+            Ok(Some(Ok(note))) => Ok(FailureNotification {
+                replica_id: note.replica_id,
+                error_message: note.error_message,
+            }),
+            Ok(Some(Err(status))) => Err(StatusError(status).into()),
+            Ok(None) => Err(PyStopIteration::new_err(())),
+            Err(_) => Err(PyTimeoutError::new_err(
+                "Timeout waiting for failure notification",
+            )),
+        }
+    }
+}
+
+#[pyclass(get_all, set_all)]
+#[derive(Clone)]
+struct FailureNotification {
+    replica_id: String,
+    error_message: String,
+}
+
 #[pymethods]
 impl QuorumResult {
     #[new]
@@ -478,7 +520,7 @@ fn convert_quorum(py: Python, q: &torchftpb::Quorum) -> PyResult<Quorum> {
 #[pyclass]
 struct LighthouseClient {
     client: LighthouseServiceClient<Channel>,
-    runtime: Runtime,
+    runtime: Arc<Runtime>,
 }
 
 #[pymethods]
@@ -487,11 +529,13 @@ impl LighthouseClient {
     #[new]
     fn new(py: Python<'_>, addr: String, connect_timeout: Duration) -> PyResult<Self> {
         py.allow_threads(move || {
-            let runtime = tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(num_threads())
-                .thread_name("torchft-lhclnt")
-                .enable_all()
-                .build()?;
+            let runtime = Arc::new(
+                tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(num_threads())
+                    .thread_name("torchft-lhclnt")
+                    .enable_all()
+                    .build()?,
+            );
             let client = runtime
                 .block_on(manager::lighthouse_client_new(addr, connect_timeout))
                 .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
@@ -586,6 +630,22 @@ impl LighthouseClient {
             Ok(())
         })
     }
+
+    #[pyo3(signature = (timeout = Duration::from_secs(5)))]
+    fn subscribe_failures(&self, py: Python<'_>, timeout: Duration) -> PyResult<FailureStream> {
+        py.allow_threads(move || {
+            let req = tonic::Request::new(SubscribeFailuresRequest {});
+            let response = self
+                .runtime
+                .block_on(self.client.clone().subscribe_failures(req))
+                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            Ok(FailureStream {
+                runtime: self.runtime.clone(),
+                stream: response.into_inner(),
+                timeout: timeout,
+            })
+        })
+    }
 }
 
 /// LighthouseServer is a GRPC server for the lighthouse service.
@@ -610,7 +670,7 @@ struct LighthouseServer {
 
 #[pymethods]
 impl LighthouseServer {
-    #[pyo3(signature = (bind, min_replicas, join_timeout_ms=None, quorum_tick_ms=None, heartbeat_timeout_ms=None))]
+    #[pyo3(signature = (bind, min_replicas, join_timeout_ms=None, quorum_tick_ms=None, heartbeat_timeout_ms=None, failure_tick_ms=None))]
     #[new]
     fn new(
         py: Python<'_>,
@@ -619,10 +679,12 @@ impl LighthouseServer {
         join_timeout_ms: Option<u64>,
         quorum_tick_ms: Option<u64>,
         heartbeat_timeout_ms: Option<u64>,
+        failure_tick_ms: Option<u64>,
     ) -> PyResult<Self> {
         let join_timeout_ms = join_timeout_ms.unwrap_or(100);
         let quorum_tick_ms = quorum_tick_ms.unwrap_or(100);
         let heartbeat_timeout_ms = heartbeat_timeout_ms.unwrap_or(5000);
+        let failure_tick_ms = failure_tick_ms.unwrap_or(1000);
 
         py.allow_threads(move || {
             let rt = tokio::runtime::Builder::new_multi_thread()
@@ -638,6 +700,7 @@ impl LighthouseServer {
                     join_timeout_ms: join_timeout_ms,
                     quorum_tick_ms: quorum_tick_ms,
                     heartbeat_timeout_ms: heartbeat_timeout_ms,
+                    failure_tick_ms: failure_tick_ms,
                 }))
                 .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
@@ -662,6 +725,22 @@ impl LighthouseServer {
         py.allow_threads(move || {
             self.handle.abort();
         })
+    }
+
+    /// inject_failure broadcasts a failure notification for the given replica.
+    ///
+    /// This helper is intended for testing `subscribe_failures` from Python.
+    #[pyo3(signature = (replica_id))]
+    fn inject_failure(&self, py: Python<'_>, replica_id: String) {
+        let lighthouse = self.lighthouse.clone();
+        let runtime = &self._runtime;
+        py.allow_threads(move || {
+            let _ = runtime.block_on(async {
+                if let Err(e) = lighthouse.inject_failure(replica_id).await {
+                    eprintln!("Failed to inject failure: {}", e);
+                }
+            });
+        });
     }
 }
 
@@ -750,6 +829,8 @@ fn _torchft(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<LighthouseServer>()?;
     m.add_class::<LighthouseClient>()?;
     m.add_class::<QuorumResult>()?;
+    m.add_class::<FailureNotification>()?;
+    m.add_class::<FailureStream>()?;
     m.add_function(wrap_pyfunction!(lighthouse_main, m)?)?;
 
     Ok(())

--- a/torchft/_torchft.pyi
+++ b/torchft/_torchft.pyi
@@ -11,8 +11,8 @@ class ManagerClient:
         checkpoint_metadata: str,
         shrink_only: bool,
         timeout: timedelta,
-        commit_failures: int,
         init_sync: bool = True,
+        commit_failures: int = 0,
     ) -> QuorumResult: ...
     def _checkpoint_metadata(self, rank: int, timeout: timedelta) -> str: ...
     def should_commit(
@@ -60,9 +60,11 @@ class LighthouseServer:
         join_timeout_ms: Optional[int] = None,
         quorum_tick_ms: Optional[int] = None,
         heartbeat_timeout_ms: Optional[int] = None,
+        failure_tick_ms: Optional[int] = None,
     ) -> None: ...
     def address(self) -> str: ...
     def shutdown(self) -> None: ...
+    def inject_failure(self, replica_id: str) -> None: ...
 
 @dataclass
 class QuorumMember:
@@ -86,6 +88,14 @@ class Quorum:
     created: Timestamp
 
 @dataclass
+class FailureNotification:
+    replica_id: str
+
+class FailureStream:
+    def __iter__(self) -> "FailureStream": ...
+    def __next__(self) -> FailureNotification: ...
+
+@dataclass
 class LighthouseClient:
     addr: str
     connect_timeout: timedelta
@@ -106,3 +116,7 @@ class LighthouseClient:
         replica_id: str,
         timeout: timedelta = timedelta(seconds=5),
     ) -> None: ...
+    def subscribe_failures(
+        self,
+        timeout: timedelta = timedelta(seconds=5),
+    ) -> FailureStream: ...

--- a/torchft/data.py
+++ b/torchft/data.py
@@ -38,15 +38,15 @@ class DistributedSampler(data.distributed.DistributedSampler):
     This will shard the input dataset into ``num_replicas*num_replica_group``
     number of shards.
 
-    Each shard rank is calculated via: ``rank + num_replicas*replica_rank``
+    Each shard rank is calculated via: ``rank + num_replicas*replica_group_id``
 
-    num_replicas and replica_rank must be the same on all workers.
+    num_replicas and replica_group_id must be the same on all workers.
     """
 
     def __init__(
         self,
         dataset: data.Dataset,
-        replica_rank: int,
+        replica_group_id: int,
         num_replica_groups: int,
         group_rank: Optional[int] = None,
         num_replicas: Optional[int] = None,
@@ -55,7 +55,7 @@ class DistributedSampler(data.distributed.DistributedSampler):
         """
         Args:
             data: the dataset to use
-            replica_rank: the group ID (0-num_replica_groups) to use for this shard of data.
+            replica_group_id: the group ID (0-num_replica_groups) to use for this shard of data.
             num_replica_groups: the max number of global replica groups
             rank: the local group rank
             num_replicas: the local group world size
@@ -65,7 +65,7 @@ class DistributedSampler(data.distributed.DistributedSampler):
         if num_replicas is None:
             num_replicas = dist.get_world_size()
 
-        self.global_rank: int = group_rank + num_replicas * replica_rank
+        self.global_rank: int = group_rank + num_replicas * replica_group_id
         self.global_world_size: int = num_replicas * num_replica_groups
 
         super().__init__(

--- a/torchft/data_test.py
+++ b/torchft/data_test.py
@@ -27,7 +27,7 @@ class TestData(TestCase):
         dataset = DummyDataset(1000)
         sampler = DistributedSampler(
             dataset,
-            replica_rank=1,
+            replica_group_id=1,
             num_replica_groups=2,
             group_rank=3,
             num_replicas=4,

--- a/torchft/lighthouse_test.py
+++ b/torchft/lighthouse_test.py
@@ -155,3 +155,72 @@ class TestLighthouse(TestCase):
 
         finally:
             lighthouse.shutdown()
+
+    def test_subscribe_failures(self) -> None:
+        """Test that subscribe_failures can be called without raising an exception."""
+        lighthouse = LighthouseServer(
+            bind="[::]:0",
+            min_replicas=1,
+        )
+        try:
+            client = LighthouseClient(
+                addr=lighthouse.address(),
+                connect_timeout=timedelta(seconds=1),
+            )
+            stream = client.subscribe_failures(timeout=timedelta(milliseconds=100))
+        finally:
+            lighthouse.shutdown()
+
+    def test_subscribe_failures_notification(self) -> None:
+        """Test that failure notifications are delivered to subscribers."""
+        lighthouse = LighthouseServer(
+            bind="[::]:0",
+            min_replicas=1,
+        )
+        try:
+            client = LighthouseClient(
+                addr=lighthouse.address(),
+                connect_timeout=timedelta(seconds=1),
+            )
+            stream = client.subscribe_failures(timeout=timedelta(seconds=1))
+            lighthouse.inject_failure("nodeX")
+            note = next(stream)
+            assert note.replica_id == "nodeX"
+        finally:
+            lighthouse.shutdown()
+
+    def test_inject_failure(self) -> None:
+        """Test that inject failure delivers a failure notification to subscribers"""
+        # Start a lighthouse server
+        server = LighthouseServer(
+            bind="[::]:0",
+            min_replicas=1,
+            join_timeout_ms=100,
+        )
+        print(f"Server address: {server.address()}")
+
+        # Create a client to subscribe to failures
+        client = LighthouseClient(server.address(), timedelta(seconds=5))
+        failure_stream = client.subscribe_failures(timedelta(seconds=5))
+
+        # Inject a failure
+        replica_id = "test_replica"
+        print(f"Injecting failure for replica: {replica_id}")
+        server.inject_failure(replica_id)
+
+        # Wait a bit for the notification to be processed
+        time.sleep(1)
+
+        # Try to get the failure notification
+        try:
+            notification = next(failure_stream)
+            print(
+                f"Received failure notification for replica: {notification.replica_id}"
+            )
+            assert notification.replica_id == replica_id, "Received wrong replica_id"
+            print("Test passed!")
+        except Exception as e:
+            print(f"Error: {e}")
+
+        # Clean up
+        server.shutdown()


### PR DESCRIPTION
# Overview

This PR improves failure detection speed of torchFT through proactive failure recovery. The Manager now listens to Lighthouse failure notifications and aborts hanging collectives immediately instead of waiting for NCCL/Gloo time-outs.

# Basic demonstration

You can experiment with proactive failure recovery mode by:

```sh
export TORCHFT_PROACTIVE_RECOVERY=1
```

With this enabled, the manager will listen to the Lighthouse server for heartbeat failures of other replica groups and break from a hanging allreduce.

You can test this out by running `train_ddp_proactive.py`

On shell 1 (one replica groups starts initial training):
```sh
export REPLICA_GROUP_ID=0
export NUM_REPLICA_GROUPS=2
export TORCHFT_PROACTIVE_RECOVERY=1

CUDA_VISIBLE_DEVICES=0 TORCHFT_LIGHTHOUSE=http://localhost:29510 torchrun --master_port=29600 --nnodes=1 --nproc_per_node=1 -- train_ddp_proactive.py
```

On shell 2 (a second replica group joins):
```sh
export REPLICA_GROUP_ID=1
export NUM_REPLICA_GROUPS=2
export TORCHFT_PROACTIVE_RECOVERY=1

CUDA_VISIBLE_DEVICES=1 TORCHFT_LIGHTHOUSE=http://localhost:29510 torchrun --master_port=29601 --nnodes=1 --nproc_per_node=1 -- train_ddp_proactive.py
```

You should observe that the process with replica group id 1 will exit early, and the process with replica group id 0 will quickly resume training. If the same script is ran with after setting `export TORCHFT_PROACTIVE_RECOVERY=0`, you should observe that the process with replica group id 1 will hang for dozens of seconds before continuing.
```sh
INFO:torchft.manager:[train_ddp_0:81a52ce4-d803-4f22-a0c3-54f3b4a88c89/0 - step 10] Setting error processor thread stop event
INFO:torchft.manager:[train_ddp_0:81a52ce4-d803-4f22-a0c3-54f3b4a88c89/0 - step 10] Waiting for error processor thread to complete
INFO:torchft.manager:[train_ddp_0:81a52ce4-d803-4f22-a0c3-54f3b4a88c89/0 - step 10] Error processor thread shutdown completed.
INFO:torchft.manager:[train_ddp_0:81a52ce4-d803-4f22-a0c3-54f3b4a88c89/0 - step 10] Setting failure listener stop event for process
INFO:torchft.manager:[train_ddp_0:81a52ce4-d803-4f22-a0c3-54f3b4a88c89/0 - step 10] Waiting for failure listener process to complete
INFO:torchft.manager:[train_ddp_0:81a52ce4-d803-4f22-a0c3-54f3b4a88c89/0 - step 10] Failure listener process shutdown completed
```

And in the Lighthouse you will observe:

```sh
2025-05-20T22:29:30.029 [INFO] [torchft::lighthouse] - Replica train_ddp_1:a581dae2-1ebc-4f93-b882-6477832fef6b timed out (last heartbeat: Instant { tv_sec: 5200692, tv_nsec: 955240591 }), sending failure notification.
2025-05-20T22:29:30.029 [INFO] [torchft::lighthouse] - Removed replica train_ddp_1:a581dae2-1ebc-4f93-b882-6477832fef6b from heartbeats and participants due to timeout.
2025-05-20T22:29:30.029 [INFO] [torchft::lighthouse] - New failure detected, resetting all participants for quorum formation.
2025-05-20T22:29:30.029 [INFO] [torchft::lighthouse] - Healthy replicas received failure notification for train_ddp_1:a581dae2-1ebc-4f93-b882-6477832fef6b
```


# Implementation

## Implementation Details

**Implementation Details:**

The proactive failure recovery mechanism involves changes in both the Rust backend and the Python `Manager`:

**Rust:**
*   **`src/lighthouse.rs`:**
    *   The `Lighthouse` server now includes a `failure_channel` (a Tokio broadcast channel).
    *   When `_failure_tick` detects a timed-out replica, it broadcasts a `FailureNotification` on this channel.
    *   A new gRPC method, `subscribe_failures`, is added to `LighthouseService`. Clients can call this to receive a stream of `FailureNotification`s.
    *   The `inject_failure` method has been added to the `LighthouseServer` (Python-exposed) and `Lighthouse` (Rust struct) to facilitate testing by manually triggering failure notifications.
*   **`src/lib.rs`:**
    *   A `FailureStream` class is introduced, wrapping the `tonic::Streaming<ProtoFailureNotification>`. Its `__next__` method allows Python to iterate over failure notifications. This method uses `py.allow_threads` around a blocking `runtime.block_on(fut)` call to fetch the next notification, allowing the GIL to be released.

**Python (Manager):**
*   **`torchft/manager.py`:**
    *   When `proactive_recovery` is enabled (via constructor argument or `TORCHFT_PROACTIVE_RECOVERY=1` environment variable), the `Manager` spawns a separate daemon process (`_failure_listener_process_main`).
    *   **`Subprocess based subscription`**: This process creates a `LighthouseClient` and calls `subscribe_failures`. It then iterates over the received failure notifications.
    *   **`Inter-Process Communication (IPC)`**: `_ManagedPipe` is used for the listener process to send errors it receives from the `Lighthouse` through the stream returned by `subscribe_failures` back to the main `Manager` process. This mimics the implementation of IPC in `BabyProcessGroup`
    *   **Error Listening**: A new thread within the main `Manager` process continuously polls the `_error_pipe`. 
    *   **Error Response**: If an exception is received, it calls `self.report_error()` and aborts the underlying process group (`self._pg.abort()`).
    *   **Error Reporting**: `self.report_error()` is now also used to flag the manager as errored when a proactive failure is detected.
    *   **Shutdown**: `Manager.shutdown()` is enhanced to gracefully stop the `_error_processor_thread` and the `_failure_listener_process`.
    *   The `subscribe_timeout` parameter for `subscribe_failures` in `_failure_listener_process_main` allows the listener process to be interruptible for clean shutdown.

## Design Rationale

I decided to use a separate process to subscribe to the failure notification because waiting on the failure stream is a blocking call. Because of the GIL, if one waits using a Python thread then it will block the main thread from functioning.

As I was implementing it, I considered three ways to implement this:

1. **GIL Release in Rust Stream Iteration**: Decouple the Python logic from the tokio streaming logic so that the GIL can be released in `lib.rs`.
2. **Asyncio**: Use `pyo3-asyncio` to create an async iterator from tokio-stream.
3. **Multiprocessing**: Use a separate process to subscribe to the failure notification.

Approach 1 and 2 are more elegant and should be more efficient as they do not involve spawning a separate process. However, I am limited by my Rust langauge understanding and was unable to implement them.

# Tests

I introduced the following tests:
*   **Rust:**
    *   `src/lighthouse.rs`:
        *   `test_subscribe_failures_delivers_notifications`: Verifies that `inject_failure` correctly sends a notification that is received by a subscriber.
        *   `test_failure_tick_single_notification_and_cleanup`: Ensures `_failure_tick` correctly identifies timeouts, broadcasts notifications once, and cleans up state.
*   **Python:**
    *   `torchft/lighthouse_test.py`:
        *   `test_subscribe_failures_notification`: Python-level test ensuring `LighthouseClient.subscribe_failures` receives notifications triggered by `LighthouseServer.inject_failure`.
        *   `test_inject_failure`: Confirms that `server.inject_failure()` leads to a notification being received by `client.subscribe_failures()`.
    *   `torchft/manager_test.py`:
        *   `test_manager_error_handler`: Tests that the `Manager` processes exceptions passed to its internal error handler.
        *   `test_direct_error_pipe`: Verifies that an exception sent directly via the IPC pipe is correctly picked up by the `Manager`.
        *   `test_manager_failure_e2e`: An end-to-end test where `LighthouseServer.inject_failure` triggers a notification that propagates through the listener process, IPC pipe, and results in the `Manager` capturing the error.

# Linter

I am still getting the following error after running `lintrunner -a`, but I couldn’t debug it:

```sh>>> General linter failure:

  Advice (pyre) command-failed
    Failed due to JSONDecodeError:
    Expecting value: line 1 column 1 (char 0)
Successfully applied all patches.
```
# Other minor changes

Note: In order to test the code using train_ddp.py, I fixed an error introduced by commit 652a00948fbd96d20fbc0e361da6026f2bf4dbba and changed the api of DistributedSampler to use `replica_group_id`.






