### PR TITLE
Reduce exploration space in quantization and collectives tests

### DIFF
--- a/torchft/collectives_test.py
+++ b/torchft/collectives_test.py
@@ -163,8 +163,8 @@ else:
 
         END_TO_END_CONFIGS: list[tuple[int, float, ReduceOp, torch.dtype]] = [
             (ts, m, o, t)
-            for ts in [256, 1024, 4096]
-            for m in [1.0, 10.0, 100.0, 1000.0]
+            for ts in [256, 1024, 2048]
+            for m in [1.0, 100.0, 1000.0]
             for o in [ReduceOp.AVG, ReduceOp.SUM]
             for t in [torch.float32, torch.float16, torch.bfloat16]
         ]
@@ -181,7 +181,7 @@ else:
                 lambda pg, _, device: self._run_all_reduce_collective(
                     pg,
                     device,
-                    3,
+                    2,
                     tensor_size,
                     multiplier,
                     0.04,
@@ -202,7 +202,7 @@ else:
                 lambda pg, _, device: self._run_reduce_scatter_collective(
                     pg,
                     device,
-                    3,
+                    2,
                     tensor_size,
                     multiplier,
                     0.05,

--- a/torchft/quantization_test.py
+++ b/torchft/quantization_test.py
@@ -107,8 +107,8 @@ else:
 
         END_TO_END_CONFIGS: list[tuple[int, float, ReduceOp, torch.dtype]] = [
             (ts, m, o, t)
-            for ts in [128, 256, 1024, 4096]
-            for m in [1.0, 10.0, 100.0, 1000.0]
+            for ts in [128, 512, 4096]
+            for m in [1.0, 100.0, 1000.0]
             for o in [ReduceOp.AVG, ReduceOp.SUM]
             for t in [torch.float32, torch.float16, torch.bfloat16]
         ]
@@ -123,7 +123,7 @@ else:
         ) -> None:
             self.run_test(
                 world_size=2,
-                tensors_num=4,
+                tensors_num=3,
                 tensor_size=tensor_size,
                 multiplier=multiplier,
                 tolerance=0.05,


### PR DESCRIPTION
In order to speed up CI this change reduces exploration space of the quantization and collectives tests while keeping the coverage high.