### PR TITLE
ci: fix missing long_description from whl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
+readme = "README.md"
 dependencies = [
     "torch>=2.7"
 ]


### PR DESCRIPTION
This fixes the missing long_description from twine check.

https://github.com/pytorch/torchft/actions/runs/17975102040/job/51126631743

Test plan:

```sh
pip wheel . -w dist
twine check --strict dist/torchft-0.1.1-cp312-cp312-linux_x86_64.whl
```