### PR TITLE
Add manual trigger to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -4,6 +4,8 @@ on:
   # run every day at 11:15am
   schedule:
     - cron:  '15 11 * * *'
+  # allow manual triggering
+  workflow_dispatch:
 
 jobs:
   nightly:


### PR DESCRIPTION
Allows us to manually kick off nightly wheel builds

https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow?tool=webui