### PR TITLE
fix allreduce usage

### DIFF
--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -423,7 +423,9 @@ class Manager:
                     torch.accelerator.current_stream(),
                 )
             else:
-                work = self._pg.allreduce([tensor], reduce_op)
+                opts = AllreduceOptions()
+                opts.reduceOp = reduce_op
+                work = self._pg.allreduce([tensor], opts)
 
             # schedule grad normalization as a continuation
             # on the Future


### PR DESCRIPTION
Summary: pass full allreduce options to the pg allreduce to avoid the watchdog abort from getting triggered

Differential Revision: D84101243


