### PR TITLE
setup basic otel logging

### DIFF
--- a/torchft/__init__.py
+++ b/torchft/__init__.py
@@ -8,6 +8,7 @@ from torchft.data import DistributedSampler
 from torchft.ddp import DistributedDataParallel
 from torchft.manager import Manager
 from torchft.optim import OptimizerWrapper as Optimizer
+from torchft.otel import setup_logger
 from torchft.process_group import (
     ProcessGroupBabyNCCL,
     ProcessGroupBabyXCCL,
@@ -15,6 +16,10 @@ from torchft.process_group import (
     ProcessGroupNCCL,
     ProcessGroupXCCL,
 )
+
+setup_logger("torchft_quorums")
+setup_logger("torchft_commits")
+setup_logger("torchft_errors")
 
 __all__ = (
     "DistributedDataParallel",

--- a/torchft/checkpointing/pg_transport_bench.py
+++ b/torchft/checkpointing/pg_transport_bench.py
@@ -47,7 +47,7 @@ def main(argv: list[str]) -> None:
 
         with _timeit("init_pg"):
             pg = ProcessGroupBabyNCCL(timeout=timeout)
-            pg.configure(store_addr=store_addr, rank=rank, world_size=2)
+            pg.configure(store_addr=store_addr, replica_id="0", rank=rank, world_size=2)
 
             t = torch.zeros(10, device=device, dtype=torch.float32)
             pg.allreduce([t], dist.ReduceOp.SUM).wait(timeout=timeout)

--- a/torchft/checkpointing/pg_transport_test.py
+++ b/torchft/checkpointing/pg_transport_test.py
@@ -27,6 +27,7 @@ class PGTransportTest(TestCase):
             pg = ProcessGroupGloo()
             pg.configure(
                 store_addr=f"localhost:{store.port}/prefix",
+                replica_id="0",
                 rank=rank,
                 world_size=world_size,
             )
@@ -52,6 +53,7 @@ class PGTransportTest(TestCase):
             pg = ProcessGroupBabyNCCL(timeout=timeout)
             pg.configure(
                 store_addr=f"localhost:{store.port}/prefix",
+                replica_id="0",
                 rank=rank,
                 world_size=world_size,
             )
@@ -78,6 +80,7 @@ class PGTransportTest(TestCase):
             pg = ProcessGroupBabyNCCL(timeout=timeout)
             pg.configure(
                 store_addr=f"localhost:{store.port}/prefix",
+                replica_id="0",
                 rank=rank,
                 world_size=world_size,
             )

--- a/torchft/parameter_server.py
+++ b/torchft/parameter_server.py
@@ -163,14 +163,14 @@ class ParameterServer(ABC):
 
         pg = cls.new_process_group()
         # client is always rank 1
-        pg.configure(store_addr, rank=1, world_size=2)
+        pg.configure(store_addr, replica_id="0", rank=1, world_size=2)
 
         return pg
 
     def _handle_session(self, session_id: str, store_addr: str) -> None:
         pg = self.new_process_group()
         # paramter server is always rank 0
-        pg.configure(store_addr, rank=0, world_size=2)
+        pg.configure(store_addr, replica_id="0", rank=0, world_size=2)
 
         self.forward(session_id, pg)
 

--- a/train_diloco.py
+++ b/train_diloco.py
@@ -18,8 +18,6 @@ USE_NCCL = os.getenv("USE_NCCL", "False") == "True"
 
 import torch
 import torch.nn.functional as F
-import torchvision
-import torchvision.transforms as transforms
 from torch import nn, optim
 from torch.distributed.elastic.multiprocessing.errors import record
 from torch.distributed.pipelining import pipeline, SplitPoint


### PR DESCRIPTION
Summary:
- setup 3 basic structured logs
  - quorums: every time a rank changes quorum id
  - commits: every time a rank commits a step
  - errors: every time a rank calls abort on process group
- allow `otel.py` to initialize loggers in multiple namespaces for each structured loggers
- pass `replica_id` to process group so that it can be logged
- flag to enable or disable otel logging

Differential Revision: D84571482


