### PR TITLE
handle exception waiting for work

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,6 +25,7 @@ jobs:
 
           sudo apt-get install -y protobuf-compiler
 
+          pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
           pip install .[dev] -v
 
           pip install -r docs/requirements.txt

--- a/torchft/device_mesh.py
+++ b/torchft/device_mesh.py
@@ -10,6 +10,7 @@ from torch.distributed import (
     init_device_mesh,
     ProcessGroup as BaseProcessGroup,
 )
+from torch.distributed._mesh_layout import _MeshLayout
 from torch.distributed.tensor.device_mesh import _mesh_resources
 
 from torchft.manager import Manager
@@ -69,12 +70,15 @@ class ManagedDeviceMesh(DeviceMesh):
         self.replicate_dim_name: str = mesh_dim_names[replicate_dim]
         self.parent = parent
         self.flatten_meshes: Dict[str, DeviceMesh] = {}
+        self._flatten_mapping: Dict[str, "DeviceMesh"] = {}
         self._device_type: str
         if mesh is not None:
             self._device_type = mesh.device_type
+            self._layout: _MeshLayout = mesh._layout
         else:
             assert parent is not None
             self._device_type = parent.device_type
+            self._layout: _MeshLayout = parent._layout
         self._flatten_mesh_list: tuple[DeviceMesh, ...] = tuple()
         self._thread_id: Optional[int] = None
         self._hash: Optional[int] = None


### PR DESCRIPTION
Summary: work.wait() can throw so wrap that in a try/catch to handle it gracefully by reporting error to the manager, leading the should_commit to fail

Differential Revision: D84880993


