### PR TITLE
Adjust the log level to avoid excessive logging.

### DIFF
--- a/src/lighthouse.rs
+++ b/src/lighthouse.rs
@@ -23,6 +23,7 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::routing::post;
 use gethostname::gethostname;
+use log::debug;
 use log::error;
 use log::info;
 use structopt::StructOpt;
@@ -291,9 +292,10 @@ impl Lighthouse {
 
     fn _quorum_tick(self: Arc<Self>, state: &mut State) -> Result<()> {
         let (quorum_met, reason) = quorum_compute(Instant::now(), state, &self.opt);
-        self.change_logger.log_if_changed(&reason);
 
         if quorum_met.is_some() {
+            self.change_logger.log_if_changed(&reason);
+
             let participants = quorum_met.unwrap();
 
             let commit_failure_replica_ids: Vec<String> = participants
@@ -330,7 +332,7 @@ impl Lighthouse {
                 created: Some(SystemTime::now().into()),
             };
 
-            info!("Quorum! {:?}", quorum);
+            debug!("Quorum! {:?}", quorum);
 
             state.prev_quorum = Some(quorum.clone());
             state.participants.clear();
@@ -490,7 +492,7 @@ impl LighthouseService for Arc<Lighthouse> {
             .requester
             .ok_or_else(|| return Status::invalid_argument("missing requester"))?;
 
-        info!(
+        debug!(
             "Received quorum request for replica {}",
             &requester.replica_id
         );

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -901,11 +901,11 @@ class Manager:
             local_should_commit,
             timeout=timeout or self._timeout,
         )
-        self._logger.info(
+        self._logger.debug(
             f"should_commit={should_commit} enough_replicas={enough_replicas}, errored={self._errored}"
         )
 
-        self.commits_logger.info(
+        self.commits_logger.debug(
             "",
             extra={
                 "job_id": os.environ.get("JOB_ID", "unknown"),
@@ -1063,6 +1063,9 @@ class _ManagerLogger:
 
     def warn(self, msg: str) -> None:
         self._logger.warn(f"{self.prefix()} {msg}")
+
+    def debug(self, msg: str) -> None:
+        self._logger.debug(f"{self.prefix()} {msg}")
 
     def exception(self, msg: str) -> None:
         self._logger.exception(f"{self.prefix()} {msg}")


### PR DESCRIPTION
By default, the current training generates too many logs. Here, some less important logs are updated to debug. If necessary, we can enable these logs by setting `RUST_LOG=DEBUG` and adjusting the python log level.