### PR TITLE
Use fully qualified domain name instead of hostname.

### DIFF
--- a/torchft/checkpointing/http_transport.py
+++ b/torchft/checkpointing/http_transport.py
@@ -171,7 +171,7 @@ class HTTPTransport(CheckpointTransport[T]):
             an HTTP address
         """
         port = self._server.socket.getsockname()[1]
-        return f"http://{socket.gethostname()}:{port}/checkpoint/"
+        return f"http://{socket.getfqdn()}:{port}/checkpoint/"
 
     def _serve(self) -> None:
         try:

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -179,7 +179,7 @@ class Manager:
         lighthouse_addr: Optional[str] = None,
         replica_id: Optional[str] = None,
         port: Optional[int] = None,
-        hostname: str = socket.gethostname(),
+        hostname: str = socket.getfqdn(),
         heartbeat_interval: timedelta = timedelta(milliseconds=100),
         checkpoint_transport: Optional[CheckpointTransport[Dict[str, T]]] = None,
         init_sync: bool = True,

--- a/torchft/parameter_server.py
+++ b/torchft/parameter_server.py
@@ -70,7 +70,7 @@ class ParameterServer(ABC):
                     session_id = str(uuid.uuid4())
 
                     store_addr = (
-                        f"{socket.gethostname()}:{ps.store.port}/session/{session_id}"
+                        f"{socket.getfqdn()}:{ps.store.port}/session/{session_id}"
                     )
 
                     logger.info(f"creating new session {session_id}")
@@ -123,7 +123,7 @@ class ParameterServer(ABC):
             an HTTP address
         """
         port = self._server.socket.getsockname()[1]
-        return f"http://{socket.gethostname()}:{port}/new_session"
+        return f"http://{socket.getfqdn()}:{port}/new_session"
 
     def _serve(self) -> None:
         try:


### PR DESCRIPTION
When using k8s, accessing the hostname might fail due to DNS issues, so fqdn can be used instead.