### PR TITLE
Replace Duration::from_secs(60) to Duration::from_mins(1)

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -17,7 +17,7 @@ pub async fn connect_once(addr: String, connect_timeout: Duration) -> Result<Cha
     let conn = Endpoint::new(addr)?
         .connect_timeout(connect_timeout)
         // Enable HTTP2 keep alives
-        .http2_keep_alive_interval(Duration::from_secs(60))
+        .http2_keep_alive_interval(Duration::from_mins(1))
         // Time taken for server to respond. 20s is default for GRPC.
         .keep_alive_timeout(Duration::from_secs(20))
         // Enable alive for idle connections.


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/monarch/pull/2066

Rust 1.91 introduced `Duration::from_mins`.

This diff replaces some instances of `Duration::from_secs` with the corresponding `Duration::from_mins`.

Differential Revision: D88434166


