### PR TITLE
Replace Duration::from_secs(3 * 60) to Duration::from_mins(3)

### DIFF
--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -81,7 +81,7 @@ mod tests {
         }
 
         assert!(try_parse_grpc_timeout(&map("3H")).unwrap() == Some(Duration::from_secs(3 * 3600)));
-        assert!(try_parse_grpc_timeout(&map("3M")).unwrap() == Some(Duration::from_secs(3 * 60)));
+        assert!(try_parse_grpc_timeout(&map("3M")).unwrap() == Some(Duration::from_mins(3)));
         assert!(try_parse_grpc_timeout(&map("3S")).unwrap() == Some(Duration::from_secs(3)));
         assert!(try_parse_grpc_timeout(&map("3m")).unwrap() == Some(Duration::from_millis(3)));
         assert!(try_parse_grpc_timeout(&map("3u")).unwrap() == Some(Duration::from_micros(3)));


### PR DESCRIPTION
Summary:
Rust 1.91 introduced `Duration::from_mins`.

This diff replaces some instances of `Duration::from_secs` with the corresponding `Duration::from_mins`.

Reviewed By: ship-it-ship-it

Differential Revision: D88522117


