### PR TITLE
Replace Duration::from_secs(3 * 3600) to Duration::from_hours(3)

### DIFF
--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -80,7 +80,7 @@ mod tests {
             map
         }
 
-        assert!(try_parse_grpc_timeout(&map("3H")).unwrap() == Some(Duration::from_secs(3 * 3600)));
+        assert!(try_parse_grpc_timeout(&map("3H")).unwrap() == Some(Duration::from_hours(3)));
         assert!(try_parse_grpc_timeout(&map("3M")).unwrap() == Some(Duration::from_secs(3 * 60)));
         assert!(try_parse_grpc_timeout(&map("3S")).unwrap() == Some(Duration::from_secs(3)));
         assert!(try_parse_grpc_timeout(&map("3m")).unwrap() == Some(Duration::from_millis(3)));


### PR DESCRIPTION
Summary:
Rust 1.91 introduced `Duration::from_hours`.

This diff replaces some instances of `Duration::from_secs` with the corresponding `Duration::from_hours`.

Reviewed By: dtolnay

Differential Revision: D88522589


