### PR TITLE
Fix CI and open telemetry API usage (#305)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ dynamic = ["version"]
 readme = "README.md"
 dependencies = [
     "torch>=2.7",
-    "opentelemetry-exporter-otlp-proto-http>=1.37.0",
-    "opentelemetry-sdk>=1.37.0",
-    "opentelemetry-api>=1.37.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.39.0",
+    "opentelemetry-sdk>=1.39.0",
+    "opentelemetry-api>=1.39.0",
 ]
 
 [project.urls]

--- a/torchft/optim.py
+++ b/torchft/optim.py
@@ -59,5 +59,5 @@ class OptimizerWrapper(Optimizer):
         return self.optim.param_groups
 
     @property
-    def state(self) -> Mapping[torch.Tensor, Any]:  # pyre-fixme[3]
+    def state(self) -> Mapping[torch.Tensor, object]:
         return self.optim.state

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -76,7 +76,7 @@ def _test_pg(
     ]
     tensor_list = [torch.empty_like(input_tensor)]
 
-    def check_tensors(arg: Any) -> None:  # pyre-ignore[2]
+    def check_tensors(arg: object) -> None:
         """Recursively check tensors for expected shape and dtype."""
         if isinstance(arg, torch.Tensor):
             assert arg.dtype == dtype, f"Output dtype mismatch: {arg.dtype} != {dtype}"
@@ -738,7 +738,10 @@ class ProcessGroupTest(TestCase):
 
         self.assertEqual(pg.group_name, str(dist.get_pg_count() - 1))
 
-        self.assertIs(_resolve_process_group(pg.group_name), pg)
+        self.assertIs(
+            _resolve_process_group(pg.group_name),  # pyre-ignore[6]: GroupName vs str
+            pg,
+        )
 
         try:
             t = torch.zeros(10)


### PR DESCRIPTION
Re-exported this PR: https://github.com/meta-pytorch/torchft/pull/305

Summary:
TorchFT CI is installing the latest `opentelemetry-sdk`, which caused breakages in some of the APIs in otel.py. This PR updates `otel.py` to use the correct APIs.

This PR also fixes TorchFT lint (pyre check was failing).

This should resolve the failing TorchFT CI failures:
https://github.com/meta-pytorch/torchft/actions/runs/19983176027/job/57313269930

This is also causing downstream CI failures in in torchtitan: https://github.com/pytorch/torchtitan/actions/workflows/integration_test_8gpu_torchft.yaml


Reviewed By: tianyu-l

Differential Revision: D89743414

Pulled By: H-Huang


