### PR TITLE
Add device-agnostic process group wrappers for distributed setup initialization

### DIFF
--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -21,12 +21,11 @@ import os
 import threading
 import time
 import warnings
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import timedelta
 from multiprocessing.connection import Connection
 from typing import (
-    Any,
     Callable,
     cast,
     Dict,
@@ -83,6 +82,11 @@ _FUTURE_EXCEPTION = "fut_exception"
 
 
 T = TypeVar("T")
+
+# Default timeout constants
+_DEFAULT_TIMEOUT_SECONDS = 60
+_DEFAULT_NCCL_TIMEOUT_SECONDS = 60.0
+_DEFAULT_XCCL_TIMEOUT_SECONDS = 60.0
 
 TORCH_NCCL_DEBUG_INFO_PIPE_FILE_ENV_VAR = "TORCH_NCCL_DEBUG_INFO_PIPE_FILE"
 # Used to trigger flight recorder if we trigger abort on the process group
@@ -410,10 +414,12 @@ class ProcessGroupWrapper(ProcessGroup):
 
     def __init__(
         self,
-        timeout: timedelta = timedelta(seconds=60),
+        timeout: Optional[timedelta] = None,
         pg: Optional[ProcessGroup] = None,
     ) -> None:
         super().__init__(0, 1)
+        if timeout is None:
+            timeout = timedelta(seconds=_DEFAULT_TIMEOUT_SECONDS)
         self._pg: Optional[BaseProcessGroup] = pg
         self._timeout = timeout
         self._replica_id: str | None = None
@@ -724,9 +730,8 @@ class _WorkAcceleratorTimeout(Work):
             # In newer versions of PyTorch work may not exist if the call was
             # not async. In these cases we can just schedule the stream timeout
             # and return.
-            if self._work is not None:
-                if not self._work.wait():
-                    return False
+            if self._work is not None and not self._work.wait():
+                return False
 
             # Always use cuda stream for timeout to avoid ProcessGroupNCCL
             # watchdog firing and crashing the process.
@@ -796,7 +801,9 @@ class ProcessGroupNCCL(ProcessGroupWrapper):
         timeout: the timeout to use for NCCL operations.
     """
 
-    def __init__(self, timeout: timedelta = timedelta(seconds=60.0)) -> None:
+    def __init__(self, timeout: Optional[timedelta] = None) -> None:
+        if timeout is None:
+            timeout = timedelta(seconds=_DEFAULT_NCCL_TIMEOUT_SECONDS)
         super().__init__(timeout)
         self._use_abort: bool = torch.cuda.nccl.version() >= (2, 25)
 
@@ -807,7 +814,8 @@ class ProcessGroupNCCL(ProcessGroupWrapper):
             warnings.warn(
                 f"{NONBLOCKING_TIMEOUT_ENV} is not set, defaulting to {timeout}. "
                 "If any nonblocking NCCL operations have already run this may "
-                "result in the default timeout of 30 minutes and hangs on error."
+                "result in the default timeout of 30 minutes and hangs on error.",
+                stacklevel=2,
             )
             os.environ[NONBLOCKING_TIMEOUT_ENV] = str(timeout.total_seconds())
 
@@ -911,7 +919,9 @@ class ProcessGroupXCCL(ProcessGroupWrapper):
         timeout: the timeout to use for XCCL operations.
     """
 
-    def __init__(self, timeout: timedelta = timedelta(seconds=60.0)) -> None:
+    def __init__(self, timeout: Optional[timedelta] = None) -> None:
+        if timeout is None:
+            timeout = timedelta(seconds=_DEFAULT_XCCL_TIMEOUT_SECONDS)
         super().__init__(timeout)
         # Check if XPU is available and XCCL is supported
         self._use_abort: bool = torch.xpu.is_available()
@@ -923,7 +933,8 @@ class ProcessGroupXCCL(ProcessGroupWrapper):
             warnings.warn(
                 f"{NONBLOCKING_TIMEOUT_ENV} is not set, defaulting to {timeout}. "
                 "If any nonblocking XCCL operations have already run this may "
-                "result in the default timeout of 30 minutes and hangs on error."
+                "result in the default timeout of 30 minutes and hangs on error.",
+                stacklevel=2,
             )
             os.environ[NONBLOCKING_TIMEOUT_ENV] = str(timeout.total_seconds())
 
@@ -1344,7 +1355,7 @@ class ManagedProcessGroup(ProcessGroupWrapper):
         if isinstance(opts, AllreduceOptions):
             return self._manager.allreduce(tensors[0], reduce_op=opts.reduceOp)
 
-        assert False, "unreachable"
+        raise AssertionError("unreachable")
 
     def size(self) -> int:
         return self._manager.num_participants()
@@ -1665,7 +1676,11 @@ class ProcessGroupBaby(ProcessGroup):
                     op_id: int = cast(int, op[1])
                     metadata: _OpMetadata = work[op_id]
 
-                    def callback(fut: Future[object], metadata: _OpMetadata) -> None:
+                    def callback(
+                        fut: Future[object],
+                        metadata: _OpMetadata,
+                        op_id: int = op_id,
+                    ) -> None:
                         try:
                             # create an event after the collective has been issued
                             # to wait on this before we call "future"
@@ -1682,7 +1697,7 @@ class ProcessGroupBaby(ProcessGroup):
                             future_pipe.send((op_id, _FUTURE_EXCEPTION, e, None))
 
                     metadata.work.get_future().add_done_callback(
-                        lambda fut: callback(fut, metadata)
+                        lambda fut, m=metadata, oid=op_id: callback(fut, m, oid)
                     )
                 elif cmd == "num_active_work":
                     req_pipe.send(len(work))
@@ -2122,19 +2137,21 @@ class ProcessGroupAccelerator(ProcessGroupWrapper):
     """
     Device-agnostic process group that automatically detects the accelerator type
     and delegates to the appropriate backend (NCCL for CUDA, XCCL for XPU).
-    
+
     This allows writing device-agnostic code without explicitly choosing between
     ProcessGroupNCCL and ProcessGroupXCCL.
-    
+
     Args:
         timeout: the timeout to use for operations.
     """
 
-    def __init__(self, timeout: timedelta = timedelta(seconds=60.0)) -> None:
+    def __init__(self, timeout: Optional[timedelta] = None) -> None:
+        if timeout is None:
+            timeout = timedelta(seconds=60.0)
         # Detect device type and create appropriate backend
         device = torch.device(torch.accelerator.current_accelerator())
         backend = dist.get_default_backend_for_device(device)
-        
+
         if backend == "nccl":
             pg = ProcessGroupNCCL(timeout=timeout)
         elif backend == "xccl":
@@ -2155,11 +2172,11 @@ class ProcessGroupBabyAccelerator(ProcessGroupBaby):
     """
     Device-agnostic baby process group that automatically detects the accelerator type
     and delegates to the appropriate backend (BabyNCCL for CUDA, BabyXCCL for XPU).
-    
+
     This runs the underlying process group in a subprocess and allows writing
     device-agnostic code without explicitly choosing between ProcessGroupBabyNCCL
     and ProcessGroupBabyXCCL.
-    
+
     Args:
         timeout: the timeout to use for operations.
     """
@@ -2169,7 +2186,7 @@ class ProcessGroupBabyAccelerator(ProcessGroupBaby):
         """Create the appropriate backend based on available accelerator."""
         device = torch.device(torch.accelerator.current_accelerator())
         backend = dist.get_default_backend_for_device(device)
-        
+
         if backend == "nccl":
             return ProcessGroupBabyNCCL._create_pg(store, rank, world_size)
         elif backend == "xccl":

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -5,11 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import gc
-import os
 import sys
-from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import timedelta
-from typing import Any, Callable, cast, Dict, List
+from typing import Any, Callable, Dict, List
 from unittest import skipIf, skipUnless, TestCase
 from unittest.mock import Mock, patch
 
@@ -25,7 +24,6 @@ from torch._C._distributed_c10d import (
     AllToAllOptions,
     BarrierOptions,
     BroadcastOptions,
-    ReduceOp,
     ReduceScatterOptions,
 )
 from torch.distributed import (
@@ -43,12 +41,11 @@ from torchft.process_group import (
     ProcessGroupAccelerator,
     ProcessGroupBabyAccelerator,
     ProcessGroupBabyGloo,
-    ProcessGroupBabyXCCL,
     ProcessGroupDummy,
     ProcessGroupGloo,
     ProcessGroupNCCL,
-    ProcessGroupXCCL,
     ProcessGroupWrapper,
+    ProcessGroupXCCL,
 )
 from torchft.work import _DummyWork
 
@@ -60,14 +57,19 @@ def dummy_init_pg() -> None:
         )
 
 
+_DEFAULT_TENSOR = torch.randn((2, 3), dtype=torch.float32)
+
+
 def _test_pg(
     pg: ProcessGroup,
-    example_tensor: torch.Tensor = torch.randn((2, 3), dtype=torch.float32),
-    skip: list[str] = [],
+    example_tensor: torch.Tensor = _DEFAULT_TENSOR,
+    skip: list[str] | None = None,
 ) -> Dict[str, dist._Work]:
     """
     Helper function to test a set of collective operations on a given process group.
     """
+    if skip is None:
+        skip = []
 
     shape: torch.Size = example_tensor.shape
     dtype: torch.dtype = example_tensor.dtype
@@ -499,7 +501,10 @@ _ALL_COLLECTIVES: List[str] = list(_COLLECTIVE_TO_FUNC.keys())
 class ProcessGroupTest(TestCase):
     @parameterized.expand(["cpu", torch.accelerator.current_accelerator().type])
     def test_gloo_apis(self, device: str) -> None:
-        if device == torch.accelerator.current_accelerator().type and not torch.accelerator.is_available():
+        if (
+            device == torch.accelerator.current_accelerator().type
+            and not torch.accelerator.is_available()
+        ):
             self.skipTest("accelerator is not available")
             return
 
@@ -625,7 +630,7 @@ class ProcessGroupTest(TestCase):
     def test_accelerator_delegation_logic(self) -> None:
         """Test that ProcessGroupAccelerator correctly delegates to NCCL/XCCL based on hardware."""
         pg = ProcessGroupAccelerator()
-        
+
         # Check that the correct backend is selected based on available hardware
         if torch.cuda.is_available():
             self.assertIsInstance(pg._pg, ProcessGroupNCCL)
@@ -641,7 +646,7 @@ class ProcessGroupTest(TestCase):
     def test_baby_accelerator_delegation_logic(self) -> None:
         """Test that ProcessGroupBabyAccelerator correctly delegates to BabyNCCL/BabyXCCL based on hardware."""
         pg = ProcessGroupBabyAccelerator()
-        
+
         # Check that the correct backend name is returned based on available hardware
         backend_name = pg.getBackendName()
         if torch.cuda.is_available():
@@ -650,7 +655,7 @@ class ProcessGroupTest(TestCase):
             self.assertEqual(backend_name, "torchft-baby-xccl")
         else:
             self.fail("No accelerator available for testing")
-        
+
         pg.shutdown()
 
     def test_baby_gloo_timeout(self) -> None:
@@ -823,8 +828,7 @@ class ProcessGroupTest(TestCase):
 
         self.assertEqual(pg.size(), 123)
 
-        works = _test_pg(pg)
-
+        _test_pg(pg)
         self.assertEqual(manager.allreduce.call_count, 2)
 
 
@@ -941,7 +945,9 @@ class MultiPgBaseTest(TestCase):
                 torch.accelerator.set_device_index(rank)
                 # Use a separate stream to avoid deadlocks between threads.
                 # Create a stream using the device-specific module (e.g., torch.cuda.Stream() or torch.xpu.Stream())
-                device_module = getattr(torch, torch.accelerator.current_accelerator().type)
+                device_module = getattr(
+                    torch, torch.accelerator.current_accelerator().type
+                )
                 torch.accelerator.set_stream(device_module.Stream())
 
             fault_rank = self.WORLD_SIZE - 1
@@ -1035,19 +1041,22 @@ class BabyGlooMultiPgTest(MultiPgBaseTest):
 
 
 @skipUnless(
-    torch.accelerator.is_available() 
+    torch.accelerator.is_available()
     and torch.accelerator.device_count() >= 2
     and (not torch.cuda.is_available() or torch.cuda.nccl.version() >= (2, 25)),
-    "needs 2 accelerator devices and NCCL >= 2.25 if CUDA is available"
+    "needs 2 accelerator devices and NCCL >= 2.25 if CUDA is available",
 )
 class BabyAcceleratorMultiPgTest(MultiPgBaseTest):
     """Device-agnostic multi-process tests using ProcessGroupBabyAccelerator."""
+
     BACKEND = "baby_accelerator"
     WORLD_SIZE = 2
 
     @parameterized.expand(_ALL_COLLECTIVES)
     def test_collective(self, collective: str) -> None:
-        self._run_parallel(collective, device=torch.accelerator.current_accelerator().type)
+        self._run_parallel(
+            collective, device=torch.accelerator.current_accelerator().type
+        )
 
     # @parameterized.expand(_ALL_COLLECTIVES)
     # def test_collective_with_resiliency(self, collective: str) -> None:
@@ -1065,13 +1074,18 @@ class AcceleratorMultiPgTest(MultiPgBaseTest):
     Device-agnostic multi-process tests using ProcessGroupAccelerator.
     This will automatically use NCCL for CUDA or XCCL for XPU.
     """
+
     BACKEND = "accelerator"
     WORLD_SIZE = 2
 
     @parameterized.expand(_ALL_COLLECTIVES)
     def test_collective(self, collective: str) -> None:
-        self._run_parallel(collective, device=torch.accelerator.current_accelerator().type)
+        self._run_parallel(
+            collective, device=torch.accelerator.current_accelerator().type
+        )
 
     @parameterized.expand(_ALL_COLLECTIVES)
     def test_collective_with_resiliency(self, collective: str) -> None:
-        self._run_with_resiliency(collective, device=torch.accelerator.current_accelerator().type)
+        self._run_with_resiliency(
+            collective, device=torch.accelerator.current_accelerator().type
+        )


### PR DESCRIPTION
As an extension of RFC https://github.com/meta-pytorch/torchft/issues/257 

The goal of this PR is to enable device-agnostic distributed setup initialization.

I've created two new classes:

1. `ProcessGroupAccelerator`
2. `ProcessGroupBabyAccelerator`

These classes automatically route to the appropriate device-specific implementation using `torch.accelerator`:
- CUDA → `ProcessGroupNCCL` / `ProcessGroupBabyNCCL`
- XPU → `ProcessGroupXCCL` / `ProcessGroupBabyXCCL`

I've added test cases to demonstrate and validate this functionality.

Future PRs will convert more test cases and code files to use this device-agnostic approach, reducing manual overhead and enabling greater flexibility and code reuse.
