### PR TITLE
Add torchcomms ProcessGroup shim for fault-tolerant reconfiguration

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,7 @@ jobs:
 
           sudo apt-get install -y protobuf-compiler
 
-          pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
+          pip install --pre torch torchvision torchcomms --index-url https://download.pytorch.org/whl/nightly/cu128
           pip install .[dev] -v
 
           pip install -r docs/requirements.txt

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,7 +23,7 @@ jobs:
 
           sudo apt-get install -y protobuf-compiler
 
-          pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
+          pip install --pre torch torchvision torchcomms --index-url https://download.pytorch.org/whl/nightly/cu128
           pip install .[dev] -v
 
           # install recent version of Rust via rustup

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -41,10 +41,10 @@ jobs:
 
         # Optionally install torch nightly, pulls latest CUDA from pip otherwise
         if [ "${{ matrix.torch-version }}" = "nightly" ]; then
-          pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
+          pip install --pre torch torchvision torchcomms --index-url https://download.pytorch.org/whl/nightly/cu128
         fi
         if [ "${{ matrix.torch-version }}" = "test" ]; then
-          pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/test/cu128
+          pip install --pre torch torchvision torchcomms --index-url https://download.pytorch.org/whl/test/cu128
         fi
 
         # Install dependencies

--- a/torchft/manager_integ_test.py
+++ b/torchft/manager_integ_test.py
@@ -6,9 +6,11 @@
 
 import copy
 import logging
+import os
 import threading
 import time
 import traceback
+import unittest
 from collections import defaultdict
 from concurrent.futures import as_completed, ThreadPoolExecutor
 from contextlib import contextmanager, ExitStack
@@ -44,6 +46,15 @@ from torchft.process_group import (
     ProcessGroupBabyNCCL,
     ProcessGroupGloo,
 )
+
+try:
+    # pyre-fixme[21]: Could not find a module corresponding to import `torchcomms`.
+    import torchcomms._comms_mccl
+    from torchft.torchcomms import ProcessGroupTorchComms
+
+    TORCHCOMMS_AVAILABLE = True
+except ImportError:
+    TORCHCOMMS_AVAILABLE = False
 
 logging.basicConfig(level=logging.INFO)
 logger: logging.Logger = logging.getLogger(__name__)
@@ -602,6 +613,161 @@ class ManagerIntegTest(TestCase):
         print(results)
         r0, r1 = results
         torch.testing.assert_close(r0, r1, check_device=False)
+
+    @unittest.skipUnless(TORCHCOMMS_AVAILABLE, "torchcomms not installed")
+    def test_ddp_healthy_torchcomms(self) -> None:
+        os.environ["TORCHCOMM_RANK"] = "0"
+        os.environ["TORCHCOMM_SIZE"] = "1"
+
+        lighthouse = LighthouseServer(
+            bind="[::]:0",
+            min_replicas=2,
+        )
+        num_replicas = 2
+        futures = []
+
+        with ThreadPoolExecutor(max_workers=num_replicas) as executor:
+            for replica_id in range(num_replicas):
+                event_injector = EventInjector()
+                runner = Runner(
+                    use_cuda=True,
+                    replica_id=replica_id,
+                    num_replicas=num_replicas,
+                    lighthouse_address=lighthouse.address(),
+                    event_injector=event_injector,
+                    train_loop=ddp_train_loop_torchcomms,
+                )
+                futures.append(executor.submit(runner.run_replica))
+
+        state_dicts = []
+
+        for fut in as_completed(futures):
+            state_dicts.append(fut.result())
+
+        lighthouse.shutdown()
+
+        for state_dict in state_dicts:
+            torch.testing.assert_close(state_dict, state_dicts[0])
+
+    @unittest.skipUnless(TORCHCOMMS_AVAILABLE, "torchcomms not installed")
+    def test_ddp_recovery_torchcomms(self) -> None:
+        os.environ["TORCHCOMM_RANK"] = "0"
+        os.environ["TORCHCOMM_SIZE"] = "1"
+
+        lighthouse = LighthouseServer(
+            bind="[::]:0",
+            min_replicas=2,
+        )
+        num_replicas = 2
+        futures = []
+
+        event_injectors = [
+            EventInjector(),
+            EventInjector().fail_at(0, 2),
+        ]
+
+        with ThreadPoolExecutor(max_workers=num_replicas) as executor:
+            for replica_id, event_injector in zip(range(num_replicas), event_injectors):
+                runner = Runner(
+                    use_cuda=True,
+                    replica_id=replica_id,
+                    num_replicas=num_replicas,
+                    lighthouse_address=lighthouse.address(),
+                    event_injector=event_injector,
+                    train_loop=ddp_train_loop_torchcomms,
+                )
+                futures.append(executor.submit(runner.run_replica))
+
+            state_dicts = []
+
+            for fut in as_completed(futures):
+                try:
+                    state_dicts.append(fut.result())
+                except Exception as e:
+                    print(e)
+                    raise
+
+        lighthouse.shutdown()
+
+        for state_dict in state_dicts:
+            torch.testing.assert_close(state_dict, state_dicts[0])
+
+        self.assertEqual(event_injectors[1].count[EventInjectorEvent.Failure], 1)
+
+
+def ddp_train_loop_torchcomms(
+    rank: int,
+    store_port: int,
+    device: torch.device,
+    runner: Runner,
+    train_loop_args: dict[str, Any] = {},
+) -> Dict[str, Dict[str, object]]:
+    with ExitStack() as stack:
+
+        def load_state_dict(state_dict: Dict[str, Dict[str, object]]) -> None:
+            m.load_state_dict(state_dict["model"])
+            optimizer.load_state_dict(state_dict["optim"])
+
+        def state_dict() -> Dict[str, Dict[str, object]]:
+            return {
+                "model": m.state_dict(),
+                "optim": optimizer.state_dict(),
+            }
+
+        print(f"worker {runner.replica_id=} {rank=} {runner.world_size=} starting")
+
+        # pyre-fixme[21]: Could not find a module corresponding to import `torchcomms`.
+        import torchcomms
+
+        comm = torchcomms.new_comm(
+            backend="mccl", device=device, name=f"mccl{rank}", enable_reconfigure=True
+        )
+        pg = ProcessGroupTorchComms(comm=comm)
+        manager = Manager(
+            pg=pg,
+            min_replica_size=2,
+            load_state_dict=load_state_dict,
+            state_dict=state_dict,
+            replica_id=str(runner.replica_id),
+            store_addr="localhost",
+            store_port=store_port,
+            rank=rank,
+            world_size=runner.world_size,
+            lighthouse_addr=runner.lighthouse_address,
+            port=19530 + runner.replica_id,
+            # pyre-fixme[6]: Incompatible parameter type
+            **runner.manager_args,
+        )
+        stack.callback(lambda: manager.shutdown(wait=False))
+
+        with INIT_LOCK:
+            torch.manual_seed(42)
+            m: nn.Module = MyModel()
+
+        m: nn.Module = DistributedDataParallel(manager, m)
+        optimizer: optim.Optimizer = OptimizerWrapper(
+            manager, optim.Adam(m.parameters())
+        )
+        criterion = nn.CrossEntropyLoss()
+
+        while True:
+            inputs = torch.rand(2, 3)
+            labels = torch.randint(4, (2,))
+
+            optimizer.zero_grad()
+            out = m(inputs)
+            loss = criterion(out, labels)
+
+            loss.backward()
+
+            optimizer.step()
+
+            if manager.current_step() >= 4:
+                break
+
+            runner.event_injector.check(rank, manager.current_step())
+
+        return state_dict()
 
 
 def all_reduce_callback(

--- a/torchft/torchcomms.py
+++ b/torchft/torchcomms.py
@@ -1,0 +1,324 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+TorchComms Process Group
+=========================
+
+This module provides a shim layer that wraps a ``torchcomms.TorchComm``
+communicator as a ``torchft.process_group.ProcessGroup``, enabling
+fault-tolerant reconfiguration via the TorchComm ``reconfigure()`` API.
+
+On each :meth:`configure` call, init-handles are exchanged via the store
+and ``TorchComm.reconfigure()`` is called.  The same ``TorchComm`` object
+is reused across reconfigurations.
+"""
+
+import logging
+from datetime import timedelta
+from typing import List, Optional, Union
+
+import torch
+
+# pyre-fixme[21]: Could not find a module corresponding to import `torchcomms`.
+import torchcomms
+from torch.distributed.distributed_c10d import (
+    AllgatherOptions,
+    AllreduceCoalescedOptions,
+    AllreduceOptions,
+    AllToAllOptions,
+    BarrierOptions,
+    BroadcastOptions,
+    ReduceOp,
+    ReduceScatterOptions,
+    Work,
+)
+from torchft.process_group import create_store_client, ProcessGroup
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class _TorchCommsWork(Work):
+    """
+    Wraps a ``torchcomms.TorchWork`` to satisfy the c10d ``Work`` interface.
+
+    Warning: this class only supports futures partially. CPU futures require the
+    user to call wait() for the future to resolve. GPU futures are automatically
+    resolved to match stream semantics.
+    """
+
+    def __init__(
+        self,
+        device: torch.device,
+        # pyre-fixme[11]: Annotation `TorchWork` is not defined as a type.
+        work: torchcomms.TorchWork | None = None,
+        value: object | None = None,
+    ) -> None:
+        super().__init__()
+        self._work: Optional[torchcomms.TorchWork] = work
+        is_cpu = device.type == "cpu"
+        self._fut: torch.futures.Future[object] = torch.futures.Future(
+            # pyre-fixme[6]: Expected `Optional[List[Union[int, str, device]]]`
+            devices=[] if is_cpu else [device]
+        )
+        self._value = value
+        # Resolve the future immediately so that DDP's
+        # get_future().then(callback) pattern works without calling wait().
+        self._fut.set_result(self._value)
+
+    def wait(self, timeout: Optional[timedelta] = None) -> bool:
+        if self._work is not None:
+            self._work.wait()
+        return True
+
+    def get_future(self) -> torch.futures.Future[object]:
+        return self._fut
+
+    def is_completed(self) -> bool:
+        if self._work is None:
+            return True
+        return self._work.is_completed()
+
+
+_REDUCE_OP_MAP: dict[ReduceOp, object] = {
+    ReduceOp.SUM: torchcomms.ReduceOp.SUM,
+    ReduceOp.PRODUCT: torchcomms.ReduceOp.PRODUCT,
+    ReduceOp.MIN: torchcomms.ReduceOp.MIN,
+    ReduceOp.MAX: torchcomms.ReduceOp.MAX,
+    ReduceOp.BAND: torchcomms.ReduceOp.BAND,
+    ReduceOp.BOR: torchcomms.ReduceOp.BOR,
+    ReduceOp.BXOR: torchcomms.ReduceOp.BXOR,
+    ReduceOp.AVG: torchcomms.ReduceOp.AVG,
+}
+
+
+def _to_torchcomms_reduce_op(
+    opts: Union[
+        ReduceOp, AllreduceOptions, AllreduceCoalescedOptions, ReduceScatterOptions
+    ],
+    # pyre-fixme[11]: Annotation `ReduceOp` is not defined as a type.
+) -> "torchcomms.ReduceOp":
+    """Convert a c10d reduce-op (or options carrying one) to ``torchcomms.ReduceOp``."""
+    if isinstance(
+        opts, (AllreduceOptions, AllreduceCoalescedOptions, ReduceScatterOptions)
+    ):
+        op = opts.reduceOp
+    elif isinstance(opts, ReduceOp):
+        op = opts
+    else:
+        op = ReduceOp.SUM
+    return _REDUCE_OP_MAP.get(op, torchcomms.ReduceOp.SUM)
+
+
+class ProcessGroupTorchComms(ProcessGroup):
+    """
+    A :class:`~torchft.process_group.ProcessGroup` backed by a
+    ``torchcomms.TorchComm`` communicator.
+
+    The caller creates a ``TorchComm`` with ``enable_reconfigure=True`` and
+    hands it to this wrapper.  Each :meth:`configure` call exchanges
+    init-handles via the store and calls ``TorchComm.reconfigure()``.  The
+    same ``TorchComm`` object is reused across reconfigurations.
+
+    Args:
+        comm: a ``torchcomms.TorchComm`` instance (with
+            ``enable_reconfigure=True``).
+        timeout: timeout for store operations and communicator creation.
+    """
+
+    def __init__(
+        self,
+        # pyre-fixme[11]: Annotation `TorchComm` is not defined as a type.
+        comm: torchcomms.TorchComm,
+        timeout: timedelta = timedelta(seconds=60),
+    ) -> None:
+        super().__init__(0, 1)
+        self._comm: Optional[torchcomms.TorchComm] = comm
+        self._timeout = timeout
+        self._world_size: int = 1
+        self._backend: str = str(comm.get_backend())
+        self._device: torch.device = comm.get_device()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def configure(
+        self,
+        store_addr: str,
+        replica_id: str,
+        rank: int,
+        world_size: int,
+        quorum_id: Optional[int] = None,
+        group_rank: Optional[int] = None,
+        group_world_size: Optional[int] = None,
+        global_ranks: Optional[list[int]] = None,
+    ) -> None:
+        assert self._comm is not None
+
+        # Reconfigure path: exchange init-handles via the store.
+        store = create_store_client(store_addr, timeout=self._timeout)
+
+        handle: str = self._comm.get_init_handle()
+
+        # Publish our handle so every other rank can read it.
+        store.set(f"torchcomms_init_handle/{rank}", handle)
+
+        # Collect handles from all ranks (ordered list → rank = index).
+        all_handles: list[str] = []
+        for i in range(world_size):
+            key = f"torchcomms_init_handle/{i}"
+            store.wait([key])
+            all_handles.append(store.get(key).decode("utf-8"))
+
+        work = self._comm.reconfigure(
+            uuid=quorum_id,
+            init_handles=all_handles,
+            timeout=self._timeout,
+        )
+        work.wait()
+
+        self._world_size = world_size
+
+    @property
+    def comm(self) -> "torchcomms.TorchComm":
+        """Return the underlying communicator (must be configured first)."""
+        assert self._comm is not None, "ProcessGroup not configured"
+        return self._comm
+
+    def size(self) -> int:
+        return self._world_size
+
+    def getBackendName(self) -> str:
+        return f"torchcomms:{self._backend}"
+
+    def abort(self) -> None:
+        if self._comm is not None:
+            try:
+                self._comm.finalize()
+            except Exception:
+                logger.debug("finalize failed during abort", exc_info=True)
+            self._comm = None
+
+    def shutdown(self) -> None:
+        self.abort()
+
+    # ------------------------------------------------------------------
+    # Collective operations
+    # ------------------------------------------------------------------
+
+    def allreduce(
+        self,
+        tensors: List[torch.Tensor],
+        opts: Union[AllreduceOptions, ReduceOp],
+    ) -> Work:
+        assert len(tensors) == 1, f"expected 1 tensor, got {len(tensors)}"
+        op = _to_torchcomms_reduce_op(opts)
+        work = self.comm.all_reduce(tensors[0], op, async_op=True)
+        return _TorchCommsWork(self._device, work, tensors)
+
+    def allreduce_coalesced(
+        self,
+        tensors: List[torch.Tensor],
+        opts: AllreduceCoalescedOptions,
+    ) -> Work:
+        assert len(tensors) == 1, f"expected 1 tensor, got {len(tensors)}"
+        op = _to_torchcomms_reduce_op(opts)
+        work = self.comm.all_reduce(tensors[0], op, async_op=True)
+        return _TorchCommsWork(self._device, work, tensors)
+
+    def allgather(
+        self,
+        output_tensors: List[List[torch.Tensor]],
+        input_tensor: List[torch.Tensor],
+        opts: AllgatherOptions,
+    ) -> Work:
+        assert len(output_tensors) == 1, f"expected 1 tensor, got {len(output_tensors)}"
+        assert len(input_tensor) == 1, f"expected 1 tensor, got {len(input_tensor)}"
+        work = self.comm.all_gather(output_tensors[0], input_tensor[0], async_op=True)
+        return _TorchCommsWork(self._device, work, output_tensors)
+
+    def allgather_into_tensor_coalesced(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[torch.Tensor],
+        opts: AllgatherOptions,
+    ) -> Work:
+        assert len(output_tensors) == 1, f"expected 1 tensor, got {len(output_tensors)}"
+        assert len(input_tensors) == 1, f"expected 1 tensor, got {len(input_tensors)}"
+        work = self.comm.all_gather_single(
+            output_tensors[0], input_tensors[0], async_op=True
+        )
+        return _TorchCommsWork(self._device, work, output_tensors)
+
+    def broadcast(
+        self,
+        tensor_list: List[torch.Tensor],
+        opts: BroadcastOptions,
+    ) -> Work:
+        assert len(tensor_list) == 1, f"expected 1 tensor, got {len(tensor_list)}"
+        root = opts.rootRank
+        work = self.comm.broadcast(tensor_list[0], root, async_op=True)
+        return _TorchCommsWork(self._device, work, tensor_list)
+
+    def reduce_scatter(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[List[torch.Tensor]],
+        opts: ReduceScatterOptions,
+    ) -> Work:
+        assert len(output_tensors) == 1, f"expected 1 tensor, got {len(output_tensors)}"
+        assert len(input_tensors) == 1, f"expected 1 tensor, got {len(input_tensors)}"
+        op = _to_torchcomms_reduce_op(opts)
+        work = self.comm.reduce_scatter(
+            output_tensors[0], input_tensors[0], op, async_op=True
+        )
+        return _TorchCommsWork(self._device, work, output_tensors)
+
+    def reduce_scatter_tensor_coalesced(
+        self,
+        output_tensors: List[torch.Tensor],
+        input_tensors: List[torch.Tensor],
+        opts: ReduceScatterOptions,
+    ) -> Work:
+        assert len(output_tensors) == 1, f"expected 1 tensor, got {len(output_tensors)}"
+        assert len(input_tensors) == 1, f"expected 1 tensor, got {len(input_tensors)}"
+        op = _to_torchcomms_reduce_op(opts)
+        work = self.comm.reduce_scatter_single(
+            output_tensors[0], input_tensors[0], op, async_op=True
+        )
+        return _TorchCommsWork(self._device, work, output_tensors)
+
+    def alltoall_base(
+        self,
+        output_buffer: torch.Tensor,
+        input_buffer: torch.Tensor,
+        output_split_sizes: List[int],
+        input_split_sizes: List[int],
+        opts: AllToAllOptions,
+    ) -> Work:
+        work = self.comm.all_to_all_single(output_buffer, input_buffer, async_op=True)
+        return _TorchCommsWork(self._device, work, output_buffer)
+
+    def barrier(self, opts: Optional[BarrierOptions] = None) -> Work:
+        work = self.comm.barrier(async_op=True)
+        return _TorchCommsWork(self._device, work)
+
+    def send(self, tensors: List[torch.Tensor], dst_rank: int, tag: int) -> Work:
+        assert len(tensors) == 1, f"expected 1 tensor, got {len(tensors)}"
+        work = self.comm.send(tensors[0], dst_rank, async_op=True)
+        return _TorchCommsWork(self._device, work, tensors)
+
+    def recv(self, tensors: List[torch.Tensor], src_rank: int, tag: int) -> Work:
+        assert len(tensors) == 1, f"expected 1 tensor, got {len(tensors)}"
+        work = self.comm.recv(tensors[0], src_rank, async_op=True)
+        return _TorchCommsWork(self._device, work, tensors)
+
+    def __repr__(self) -> str:
+        return (
+            f"ProcessGroupTorchComms(backend={self._backend!r}, "
+            f"device={self._device}, configured={self._comm is not None})"
+        )

--- a/torchft/torchcomms_test.py
+++ b/torchft/torchcomms_test.py
@@ -1,0 +1,327 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from datetime import timedelta
+from typing import Dict, TYPE_CHECKING
+from unittest import skipUnless, TestCase
+from unittest.mock import MagicMock
+
+import torch
+import torch.distributed as dist
+from torch import nn
+from torch._C._distributed_c10d import (
+    AllgatherOptions,
+    AllreduceCoalescedOptions,
+    AllreduceOptions,
+    AllToAllOptions,
+    BarrierOptions,
+    BroadcastOptions,
+    ReduceOp,
+    ReduceScatterOptions,
+)
+from torch.distributed import ProcessGroup as BaseProcessGroup, TCPStore
+
+try:
+    # pyre-fixme[21]: Could not find a module corresponding to import `torchcomms`.
+    import torchcomms
+
+    # pyre-fixme[21]: Could not find a module corresponding to import `torchcomms`.
+    import torchcomms._comms_mccl
+
+    TORCHCOMMS_AVAILABLE = True
+except ImportError:
+    TORCHCOMMS_AVAILABLE = False
+
+if TYPE_CHECKING:
+    from torchft.torchcomms import ProcessGroupTorchComms
+
+
+def _dummy_init_pg() -> None:
+    if not dist.is_initialized():
+        dist.init_process_group(
+            backend="gloo", rank=0, world_size=1, store=dist.HashStore()
+        )
+
+
+def _test_torchcomms_pg(
+    pg: BaseProcessGroup,
+    example_tensor: torch.Tensor = torch.randn((2, 3), dtype=torch.float32),
+) -> Dict[str, dist._Work]:
+    """Test collective operations on a ProcessGroupTorchComms instance."""
+    shape: torch.Size = example_tensor.shape
+    dtype: torch.dtype = example_tensor.dtype
+    world_size = dist.get_world_size(pg)
+
+    input_tensor = example_tensor.clone()
+    output_tensors = [[torch.empty_like(input_tensor) for _ in range(world_size)]]
+    tensor_list = [torch.empty_like(input_tensor)]
+
+    def check_tensors(arg: object) -> None:
+        if isinstance(arg, torch.Tensor):
+            assert arg.dtype == dtype, f"dtype mismatch: {arg.dtype} != {dtype}"
+            assert arg.shape == shape, f"shape mismatch: {arg.shape} != {shape}"
+        elif isinstance(arg, (list, tuple)):
+            for item in arg:
+                check_tensors(item)
+
+    collectives = [
+        ("allreduce", ([input_tensor], AllreduceOptions())),
+        ("allreduce", ([input_tensor], ReduceOp.SUM)),
+        ("allreduce_coalesced", ([input_tensor], AllreduceCoalescedOptions())),
+        ("allgather", (output_tensors, [input_tensor], AllgatherOptions())),
+        # TODO: mccl std::bad_alloc
+        (
+            "allgather_into_tensor_coalesced",
+            (output_tensors[0], [input_tensor], AllgatherOptions()),
+        ),
+        (
+            "alltoall_base",
+            (
+                output_tensors[0][0],
+                input_tensor,
+                [input_tensor.shape[0]],
+                [input_tensor.shape[0]],
+                AllToAllOptions(),
+            ),
+        ),
+        ("barrier", (BarrierOptions(),)),
+        # TODO: mccl std::bad_alloc
+        # ("broadcast", (tensor_list, BroadcastOptions())),
+        # ("broadcast_one", (input_tensor, 0)),
+        (
+            "reduce_scatter",
+            (output_tensors[0], [[input_tensor]], ReduceScatterOptions()),
+        ),
+        (
+            "reduce_scatter_tensor_coalesced",
+            (output_tensors[0], [input_tensor], ReduceScatterOptions()),
+        ),
+    ]
+
+    works: Dict[str, dist._Work] = {}
+    for coll_str, args in collectives:
+        try:
+            coll = getattr(pg, coll_str)
+            work = coll(*args)
+            works[coll_str] = work
+            work.wait()
+            # Verify get_future() returns a resolved future
+            fut = work.get_future()
+            assert fut.done(), f"future for {coll_str} should be done after wait()"
+            check_tensors(args)
+        except Exception as e:
+            print(f"{coll_str}: {e}")
+            if "not implemented" in str(e):
+                continue
+            raise
+    return works
+
+
+_mccl_comm_counter = 0
+
+
+@skipUnless(TORCHCOMMS_AVAILABLE, "torchcomms not installed")
+@skipUnless(torch.cuda.is_available(), "CUDA not available")
+class ProcessGroupTorchCommsMcclTest(TestCase):
+    """Tests for ProcessGroupTorchComms with mccl backend."""
+
+    def setUp(self) -> None:
+        _dummy_init_pg()
+        os.environ["RANK"] = "0"
+        os.environ["WORLD_SIZE"] = "1"
+
+    def _make_pg(self) -> "ProcessGroupTorchComms":
+        from torchft.torchcomms import ProcessGroupTorchComms
+
+        global _mccl_comm_counter
+        name = f"test_mccl_{_mccl_comm_counter}"
+        _mccl_comm_counter += 1
+
+        comm = torchcomms.new_comm(
+            backend="mccl",
+            device=torch.device("cuda:0"),
+            name=name,
+            enable_reconfigure=True,
+        )
+        return ProcessGroupTorchComms(comm=comm, timeout=timedelta(seconds=60))
+
+    def test_mccl_apis(self) -> None:
+        store = TCPStore(
+            host_name="localhost", port=0, is_master=True, wait_for_workers=False
+        )
+
+        pg = self._make_pg()
+
+        store_addr = f"localhost:{store.port}/prefix"
+        pg.configure(store_addr, "0", 0, 1, quorum_id=0)
+
+        self.assertEqual(pg.size(), 1)
+        self.assertEqual(pg.getBackendName(), "torchcomms:mccl")
+        self.assertIsNotNone(pg.comm)
+
+        _test_torchcomms_pg(pg, torch.tensor([2], dtype=torch.float32, device="cuda:0"))
+
+    def test_reconfigure(self) -> None:
+        """Verify that calling configure() twice works."""
+        store = TCPStore(
+            host_name="localhost", port=0, is_master=True, wait_for_workers=False
+        )
+
+        pg = self._make_pg()
+
+        # First configure
+        store_addr = f"localhost:{store.port}/prefix1"
+        pg.configure(store_addr, "0", 0, 1, quorum_id=0)
+        self.assertEqual(pg.size(), 1)
+
+        # Run a collective
+        t = torch.tensor([1.0], device="cuda:0")
+        work = pg.allreduce([t], AllreduceOptions())
+        work.wait()
+        self.assertEqual(t.item(), 1.0)
+
+        # Reconfigure
+        store_addr2 = f"localhost:{store.port}/prefix2"
+        pg.configure(store_addr2, "0", 0, 1, quorum_id=1)
+        self.assertEqual(pg.size(), 1)
+
+        # Run another collective after reconfigure
+        t2 = torch.tensor([2.0], device="cuda:0")
+        work2 = pg.allreduce([t2], AllreduceOptions())
+        work2.wait()
+        self.assertEqual(t2.item(), 2.0)
+
+    def test_shutdown(self) -> None:
+        store = TCPStore(
+            host_name="localhost", port=0, is_master=True, wait_for_workers=False
+        )
+
+        pg = self._make_pg()
+        store_addr = f"localhost:{store.port}/prefix"
+        pg.configure(store_addr, "0", 0, 1, quorum_id=0)
+        pg.shutdown()
+        self.assertIsNone(pg._comm)
+
+    def test_abort(self) -> None:
+        store = TCPStore(
+            host_name="localhost", port=0, is_master=True, wait_for_workers=False
+        )
+
+        pg = self._make_pg()
+        store_addr = f"localhost:{store.port}/prefix"
+        pg.configure(store_addr, "0", 0, 1, quorum_id=0)
+        pg.abort()
+        self.assertIsNone(pg._comm)
+
+    def test_ddp_forward_backward(self) -> None:
+        """Integration test: run a DDP forward/backward pass over the PG."""
+        store = TCPStore(
+            host_name="localhost", port=0, is_master=True, wait_for_workers=False
+        )
+
+        pg = self._make_pg()
+        store_addr = f"localhost:{store.port}/prefix"
+        pg.configure(store_addr, "0", 0, 1, quorum_id=0)
+
+        m = nn.Linear(3, 4).cuda()
+        try:
+            m = torch.nn.parallel.DistributedDataParallel(m, process_group=pg)
+        except Exception as e:
+            if "std::bad_alloc" in str(e):
+                self.skipTest("mccl doesn't support broadcast")
+            else:
+                raise
+
+        out = m(torch.rand(2, 3, device="cuda:0"))
+        loss = out.sum()
+        loss.backward()
+
+        # Verify gradients were computed and synced via the PG
+        for p in m.parameters():
+            if p.requires_grad:
+                self.assertIsNotNone(p.grad)
+
+
+@skipUnless(TORCHCOMMS_AVAILABLE, "torchcomms not installed")
+class ProcessGroupTorchCommsTest(TestCase):
+    """Tests for ProcessGroupTorchComms (reconfigure path)."""
+
+    def setUp(self) -> None:
+        _dummy_init_pg()
+
+    def test_reconfigure_handle_exchange(self) -> None:
+        """Test the reconfigure code path with a mocked TorchComm."""
+        from torchft.torchcomms import ProcessGroupTorchComms
+
+        store = TCPStore(
+            host_name="localhost", port=0, is_master=True, wait_for_workers=False
+        )
+
+        # Build a mock comm whose get_init_handle succeeds (reconfigure path).
+        mock_comm = MagicMock()
+        mock_comm.get_init_handle.return_value = "handle_rank0"
+        mock_comm.get_backend.return_value = "nccl"
+        mock_comm.get_device.return_value = torch.device("cpu")
+
+        mock_work = MagicMock()
+        mock_comm.reconfigure.return_value = mock_work
+
+        pg = ProcessGroupTorchComms(comm=mock_comm, timeout=timedelta(seconds=60))
+
+        store_addr = f"localhost:{store.port}/prefix"
+        pg.configure(store_addr, "0", 0, 1, quorum_id=0)
+
+        # reconfigure should have been called with uuid=0 and the handle list.
+        mock_comm.reconfigure.assert_called_once()
+        call_kwargs = mock_comm.reconfigure.call_args
+        self.assertEqual(call_kwargs.kwargs["uuid"], 0)
+        self.assertEqual(call_kwargs.kwargs["init_handles"], ["handle_rank0"])
+        mock_work.wait.assert_called_once()
+
+        # Second configure with a different quorum_id.
+        mock_comm.reconfigure.reset_mock()
+        mock_work.reset_mock()
+        store_addr2 = f"localhost:{store.port}/prefix2"
+        pg.configure(store_addr2, "0", 0, 1, quorum_id=1)
+
+        call_kwargs2 = mock_comm.reconfigure.call_args
+        self.assertEqual(call_kwargs2.kwargs["uuid"], 1)
+
+    def test_work_is_completed(self) -> None:
+        """Test _TorchCommsWork.is_completed() delegation."""
+        from torchft.torchcomms import _TorchCommsWork
+
+        device = torch.device("cpu")
+
+        # None work is always completed
+        w = _TorchCommsWork(device, None)
+        self.assertTrue(w.is_completed())
+        self.assertTrue(w.wait())
+
+        # Delegated work
+        mock_work = MagicMock()
+        mock_work.is_completed.return_value = False
+        w = _TorchCommsWork(device, mock_work)
+        self.assertFalse(w.is_completed())
+
+        mock_work.is_completed.return_value = True
+        self.assertTrue(w.is_completed())
+
+    def test_work_get_future(self) -> None:
+        """Test _TorchCommsWork.get_future() returns a future."""
+        from torchft.torchcomms import _TorchCommsWork
+
+        device = torch.device("cpu")
+
+        # With a mock work object, wait() resolves the CPU future
+        value = torch.tensor([1.0])
+        mock_work = MagicMock()
+        w = _TorchCommsWork(device, mock_work, value=value)
+        w.wait()
+        fut = w.get_future()
+        self.assertTrue(fut.done())
+        self.assertIs(fut.value(), value)


### PR DESCRIPTION
## Summary
- Adds `ProcessGroupTorchComms` which wraps a `torchcomms.TorchComm` communicator as a `torchft.process_group.ProcessGroup`
- Translates all c10d ProcessGroup collective operations (allreduce, allgather, broadcast, reduce_scatter, alltoall, barrier, send, recv) to the torchcomms API

## Test plan

Added basic unit tests and E2E integration test using mccl.

```
pytest torchft/torchcomms_test.py
pytest torchft/manager_integ_test.py -k torchcomms
```