### PR TITLE
Fix NCCL Error 7 by removing eager_connect_single_device

### DIFF
--- a/torchft/collectives_test.py
+++ b/torchft/collectives_test.py
@@ -95,13 +95,9 @@ else:
 
                 work = allreduce_quantized(tensors, reduce_op, pg)
                 work.wait()
-                # Synchronize to ensure non-blocking NCCL operations are
-                # fully complete before the next iteration.
-                cuda.synchronize()
 
                 work = pg.allreduce([expected], reduce_op)
                 work.get_future().wait()
-                cuda.synchronize()
 
                 _check_result_tolerance(actual, expected, tolerance)
 
@@ -146,7 +142,6 @@ else:
 
                 work = reduce_scatter_quantized(actual_output, tensors, opts, pg)
                 work.get_future().wait()
-                cuda.synchronize()
 
                 padded_sizes = get_padded_sizes(tensors, world_size)
                 padded_numel = sum(s.numel() for s in padded_sizes)
@@ -162,7 +157,6 @@ else:
 
                 work = pg.reduce_scatter([expected_output], [[padded_input]], opts)
                 work.get_future().wait()
-                cuda.synchronize()
 
                 _check_result_tolerance(actual_output, expected_output, tolerance)
 

--- a/torchft/collectives_test.py
+++ b/torchft/collectives_test.py
@@ -95,9 +95,13 @@ else:
 
                 work = allreduce_quantized(tensors, reduce_op, pg)
                 work.wait()
+                # Synchronize to ensure non-blocking NCCL operations are
+                # fully complete before the next iteration.
+                cuda.synchronize()
 
                 work = pg.allreduce([expected], reduce_op)
                 work.get_future().wait()
+                cuda.synchronize()
 
                 _check_result_tolerance(actual, expected, tolerance)
 
@@ -142,6 +146,7 @@ else:
 
                 work = reduce_scatter_quantized(actual_output, tensors, opts, pg)
                 work.get_future().wait()
+                cuda.synchronize()
 
                 padded_sizes = get_padded_sizes(tensors, world_size)
                 padded_numel = sum(s.numel() for s in padded_sizes)
@@ -157,6 +162,7 @@ else:
 
                 work = pg.reduce_scatter([expected_output], [[padded_input]], opts)
                 work.get_future().wait()
+                cuda.synchronize()
 
                 _check_result_tolerance(actual_output, expected_output, tolerance)
 

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -864,9 +864,13 @@ class ProcessGroupNCCL(ProcessGroupWrapper):
         # pyre-fixme[16]: no attribute ProcessGroupNCCL
         backend_class = BaseProcessGroupNCCL(store, rank, world_size, opts)
         backend_class._set_sequence_number_for_group()
-        backend_class.eager_connect_single_device(
-            torch.device(torch.accelerator.current_device_index())
-        )
+        # NOTE: We intentionally do NOT call eager_connect_single_device here.
+        # In non-blocking mode (blocking=False), eager_connect starts an async
+        # communicator init that cannot be waited on through Python APIs. The
+        # first collective would then fail with "NCCL Error 7: operation in
+        # progress". Instead, we let the communicator be lazily initialized by
+        # the first collective, which properly handles the async init inside
+        # its ncclGroupStart/ncclGroupEnd context.
         pg._register_backend(
             torch.device("cuda"), ProcessGroup.BackendType.NCCL, backend_class
         )


### PR DESCRIPTION
## Summary
- Remove `eager_connect_single_device` from `ProcessGroupNCCL._create_pg` to fix "NCCL Error 7: operation in progress" failures
- In non-blocking NCCL mode (`blocking=False`), `eager_connect_single_device` starts an async communicator init that cannot be waited on through Python APIs. The first collective then fails because the init hasn't completed.
- Without eager_connect, the communicator is lazily initialized by the first collective, which properly handles the async init inside its `ncclGroupStart`/`ncclGroupEnd` context.

## Test plan
- CI GPU tests (`QuantizedAllReduceTest`) should pass, which have been failing since ~Dec 2025 due to a PyTorch nightly regression in non-blocking NCCL + eager_connect interaction