### PR TITLE
Fix #316: SIGSEV during long running training when using asynchronous...

### DIFF
--- a/torchft/futures.py
+++ b/torchft/futures.py
@@ -28,11 +28,18 @@ class _TimerHandle:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._timer_handle: Optional[asyncio.TimerHandle] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._cancelled = False
 
-    def set_timer_handle(self, timer_handle: asyncio.TimerHandle) -> None:
+    def set_timer_handle(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        timer_handle: asyncio.TimerHandle,
+    ) -> None:
         with self._lock:
+            self._loop = loop
             if self._cancelled:
+                # Called from within the event loop thread, so direct cancel is safe.
                 timer_handle.cancel()
                 self._timer_handle = None
             else:
@@ -43,8 +50,16 @@ class _TimerHandle:
             assert not self._cancelled, "timer can only be cancelled once"
             self._cancelled = True
             if self._timer_handle is not None:
-                self._timer_handle.cancel()
+                timer_handle = self._timer_handle
+                loop = self._loop
                 self._timer_handle = None
+                if loop is not None:
+                    # Schedule cancellation on the event loop thread to avoid
+                    # SIGSEGV when using uvloop, where uv_timer_stop is not
+                    # thread-safe and must be called from the event loop thread.
+                    loop.call_soon_threadsafe(timer_handle.cancel)
+                else:
+                    timer_handle.cancel()
 
 
 class _TimeoutManager:
@@ -228,7 +243,7 @@ class _TimeoutManager:
             timeout.total_seconds(),
             callback,
         )
-        handle.set_timer_handle(timer_handle)
+        handle.set_timer_handle(loop, timer_handle)
 
     @contextmanager
     def context_timeout(

--- a/torchft/futures_test.py
+++ b/torchft/futures_test.py
@@ -13,6 +13,7 @@ import torch
 from torch.futures import Future
 from torchft.futures import (
     _TIMEOUT_MANAGER,
+    _TimerHandle,
     context_timeout,
     future_timeout,
     future_wait,
@@ -96,6 +97,23 @@ class FuturesTest(TestCase):
         del item
 
         self.assertEqual(_TIMEOUT_MANAGER._clear_del_queue(), 1)
+
+    def test_timer_handle_cancel_uses_call_soon_threadsafe(self) -> None:
+        """Cancelling from outside the event loop must go via call_soon_threadsafe.
+
+        With uvloop the underlying uv_timer_stop is NOT thread-safe; calling it
+        directly from a non-event-loop thread causes a SIGSEGV (issue #316).
+        """
+        mock_loop = Mock()
+        mock_timer_handle = Mock()
+
+        handle = _TimerHandle()
+        handle.set_timer_handle(mock_loop, mock_timer_handle)
+        handle.cancel()
+
+        # cancel() must delegate to call_soon_threadsafe, not call directly
+        mock_loop.call_soon_threadsafe.assert_called_once_with(mock_timer_handle.cancel)
+        mock_timer_handle.cancel.assert_not_called()
 
     # Test that when a timeout handle gets stuck, `sys.exit(1)` is called
     @patch("sys.exit")


### PR DESCRIPTION
Closes #316

Fix SIGSEGV in `_TimerHandle.cancel()` when using uvloop by scheduling timer cancellation via `call_soon_threadsafe` instead of calling it directly from a non-event-loop thread.

## Changes

**`torchft/futures.py`**
- `_TimerHandle.__init__`: added `self._loop` field to store the event loop reference alongside the timer handle.
- `_TimerHandle.set_timer_handle`: added `loop: asyncio.AbstractEventLoop` parameter; stores it in `self._loop` before setting the handle.
- `_TimerHandle.cancel`: instead of calling `self._timer_handle.cancel()` directly, now dispatches `loop.call_soon_threadsafe(timer_handle.cancel)` when a loop is available. Falls back to direct cancellation only when `loop` is `None`.
- `_TimeoutManager._schedule_timeout` (line 243): passes `loop` as the first argument to `handle.set_timer_handle(loop, timer_handle)`.

**`torchft/futures_test.py`**
- Added `test_timer_handle_cancel_uses_call_soon_threadsafe`: creates a `_TimerHandle` with a `Mock` loop and timer handle, calls `cancel()`, and asserts that `mock_loop.call_soon_threadsafe` was called with `mock_timer_handle.cancel` while `mock_timer_handle.cancel` was **not** called directly.

## Motivation

`uv_timer_stop` (the underlying C function invoked by uvloop's `TimerHandle.cancel()`) is not thread-safe. When `_TimerHandle.cancel()` was called from the training thread — outside the event loop thread — during an async quorum timeout teardown, it raced with the event loop, corrupting internal uvloop state and producing a SIGSEGV:

```
PC: @ 0x7fe555ebb7ba  (unknown)  uv_timer_stop
  File "torchft/futures.py", line 46 in cancel
  File "torchft/futures.py", line 248 in context_timeout
  ...
  File "torchft/process_group.py", line 759 in _stream_timeout
```

`call_soon_threadsafe` serializes the cancellation onto the event loop thread, where it is safe to call `uv_timer_stop`. The fallback direct-cancel path is retained for cases where no loop is stored (e.g., pre-`set_timer_handle` cancellation), which already executes on the correct thread per the existing code path.

## Testing

Unit test added in `futures_test.py::FuturesTest::test_timer_handle_cancel_uses_call_soon_threadsafe`:

```
python -m pytest torchft/futures_test.py::FuturesTest::test_timer_handle_cancel_uses_call_soon_threadsafe -v
PASSED
```

The existing `futures_test.py` suite continues to pass. The crash itself required B200 nodes with uvloop under load to reproduce consistently; the unit test pins the threading contract without requiring the full environment.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*