### PR TITLE
Fix ProcessGroupGloo crash when setting unsupported backend options

### DIFF
--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -653,9 +653,15 @@ class ProcessGroupGloo(ProcessGroupWrapper):
         backend_class._set_sequence_number_for_group()
 
         if self._global_ranks:
-            backend_class.options.global_ranks_in_group = self._global_ranks
+            try:
+                backend_class.options.global_ranks_in_group = self._global_ranks
+            except AttributeError:
+                pass
         if self._group_rank and self._group_world_size:
-            backend_class.options.group_name = f"torchft_quorum_{self._quorum_id}_rank_{self._group_rank % self._group_world_size}"
+            try:
+                backend_class.options.group_name = f"torchft_quorum_{self._quorum_id}_rank_{self._group_rank % self._group_world_size}"
+            except AttributeError:
+                pass
 
         pg._register_backend(
             torch.device("cpu"), ProcessGroup.BackendType.GLOO, backend_class


### PR DESCRIPTION
### Title

Fix `ProcessGroupGloo` crash when setting unsupported backend options

### Summary

This MR fixes a runtime crash in `ProcessGroupGloo._create_pg()` caused by unconditional assignment to Gloo backend options that are not present in PyTorch's `ProcessGroupGloo._Options`.

### Why this change is needed

Current code in `ProcessGroupGloo._create_pg()` does:

- `backend_class.options.global_ranks_in_group = ...`
- `backend_class.options.group_name = ...`

For Gloo, `backend_class.options` is `torch._C._distributed_c10d._Options`, which does not expose these attributes (it typically only has `backend`). Entering quorum on Gloo can therefore raise `AttributeError` and fail immediately.

NCCL path is not affected because NCCL `Options` does provide these fields.

### Root cause

The code assumes Gloo options support the same attributes as NCCL options.

### What this MR changes

In `torchft/process_group.py` (`ProcessGroupGloo._create_pg`):

- wrap assignment of `global_ranks_in_group` in `try/except AttributeError`
- wrap assignment of `group_name` in `try/except AttributeError`

So unsupported optional fields are skipped on Gloo instead of crashing.

### Behavioral impact

- prevents Gloo quorum initialization from hard-failing with `AttributeError`
- no behavior change for NCCL path
- keeps compatibility across PyTorch versions where Gloo options surface differs