### PR TITLE
Add xpu support to the Unit Tests

### DIFF
--- a/torchft/_test/diloco_trainer.py
+++ b/torchft/_test/diloco_trainer.py
@@ -19,6 +19,7 @@ from torchft.manager_integ_test import MyModel, Runner
 from torchft.process_group import (
     FakeProcessGroupWrapper,
     ProcessGroupBabyNCCL,
+    ProcessGroupBabyXCCL,
     ProcessGroupGloo,
 )
 
@@ -153,6 +154,8 @@ class DiLoCoTrainer:
     def setup_pg(self) -> FakeProcessGroupWrapper:
         if self.device.type == "cuda":
             return FakeProcessGroupWrapper(ProcessGroupBabyNCCL())
+        elif self.device.type == "xpu":
+            return FakeProcessGroupWrapper(ProcessGroupBabyXCCL())
         else:
             return FakeProcessGroupWrapper(
                 ProcessGroupGloo(timeout=timedelta(seconds=10))

--- a/torchft/checkpointing/http_transport_test.py
+++ b/torchft/checkpointing/http_transport_test.py
@@ -29,12 +29,17 @@ class TestHTTPTransport(TestCase):
         ]
     )
     def test_checkpoint_server(self, name: str, num_chunks: int) -> None:
+        # Exercise the accelerator staging path (CUDA or XPU) when one is
+        # present, otherwise fall back to CPU tensors.
+        accel_device = (
+            torch.accelerator.current_accelerator()
+            if torch.accelerator.is_available()
+            else torch.device("cpu")
+        )
         expected: Dict[str, object] = {
             "state": "dict",
             "tensor": torch.rand(5, 2),
-            "cuda": torch.rand(
-                2, 3, device="cuda" if torch.cuda.is_available() else "cpu"
-            ),
+            "accelerator": torch.rand(2, 3, device=accel_device),
         }
         state_dict_fn = MagicMock()
         state_dict_fn.return_value = expected
@@ -133,6 +138,35 @@ class TestHTTPTransport(TestCase):
             )
 
         run_multi_recovery_test(self, init, device=device)
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+    @skipUnless(torch.xpu.is_available(), "XPU is not available")
+    def test_multi_http_transport_xpu(self) -> None:
+        device = torch.device("xpu")
+
+        def init(rank: int, world_size: int) -> CheckpointTransport[Dict[str, object]]:
+            return HTTPTransport(
+                timeout=timedelta(seconds=10),
+                num_chunks=0,
+            )
+
+        run_multi_recovery_test(self, init, device=device)
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+    @skipUnless(torch.accelerator.is_available(), "no accelerator is available")
+    def test_stream_is_created_for_accelerator(self) -> None:
+        """HTTPTransport stages through a device stream when an accelerator exists."""
+        acc = torch.accelerator.current_accelerator()
+        assert acc is not None
+
+        transport = HTTPTransport(timeout=timedelta(seconds=10), num_chunks=0)
+        try:
+            stream = transport._stream
+            self.assertIsNotNone(stream)
+            assert stream is not None
+            self.assertEqual(stream.device.type, acc.type)
+        finally:
+            transport.shutdown()
 
     def test_benchmark(self) -> None:
         bench_main(

--- a/torchft/checkpointing/pg_transport_test.py
+++ b/torchft/checkpointing/pg_transport_test.py
@@ -16,7 +16,11 @@ from torchft.checkpointing.transport_test import (
     make_state_dict,
     run_multi_recovery_test,
 )
-from torchft.process_group import ProcessGroupBabyNCCL, ProcessGroupGloo
+from torchft.process_group import (
+    ProcessGroupBabyNCCL,
+    ProcessGroupBabyXCCL,
+    ProcessGroupGloo,
+)
 
 
 class PGTransportTest(TestCase):
@@ -83,6 +87,62 @@ class PGTransportTest(TestCase):
             torch.cuda.set_device(rank)
 
             pg = ProcessGroupBabyNCCL(timeout=timeout)
+            pg.configure(
+                store_addr=f"localhost:{store.port}/prefix",
+                replica_id="0",
+                rank=rank,
+                world_size=world_size,
+            )
+
+            return PGTransport[dict[str, object]](
+                pg,
+                timeout=timeout,
+                device=device,
+                state_dict=state_dict,
+            )
+
+        run_multi_recovery_test(self, init, device=device)
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @skipUnless(torch.xpu.device_count() >= 3, "need three XPU devices")
+    def test_pg_transport_baby_xccl(self) -> None:
+        store: TCPStore = TCPStore(
+            host_name="localhost", port=0, is_master=True, wait_for_workers=False
+        )
+        device: torch.device = torch.device("xpu")
+        timeout: timedelta = timedelta(seconds=10)
+
+        def init(rank: int, world_size: int) -> CheckpointTransport[dict[str, object]]:
+            torch.xpu.set_device(rank)
+
+            pg = ProcessGroupBabyXCCL(timeout=timeout)
+            pg.configure(
+                store_addr=f"localhost:{store.port}/prefix",
+                replica_id="0",
+                rank=rank,
+                world_size=world_size,
+            )
+
+            return PGTransport[dict[str, object]](pg, timeout=timeout, device=device)
+
+        run_multi_recovery_test(self, init, device=device)
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @skipUnless(torch.xpu.device_count() >= 3, "need three XPU devices")
+    def test_pg_transport_baby_xccl_inplace(self) -> None:
+        store: TCPStore = TCPStore(
+            host_name="localhost", port=0, is_master=True, wait_for_workers=False
+        )
+        device: torch.device = torch.device("xpu")
+        timeout: timedelta = timedelta(seconds=10)
+
+        def state_dict() -> dict[str, object]:
+            return make_state_dict(device)
+
+        def init(rank: int, world_size: int) -> CheckpointTransport[dict[str, object]]:
+            torch.xpu.set_device(rank)
+
+            pg = ProcessGroupBabyXCCL(timeout=timeout)
             pg.configure(
                 store_addr=f"localhost:{store.port}/prefix",
                 replica_id="0",

--- a/torchft/collectives_test.py
+++ b/torchft/collectives_test.py
@@ -5,13 +5,13 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from typing import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Callable, List
 from unittest import skipUnless, TestCase
 
 import torch
 import torch.distributed as dist
 from parameterized import parameterized
-from torch import cuda
 from torch.distributed import ReduceOp, ReduceScatterOptions
 from torchft import _test_utils
 from torchft.process_group import ProcessGroup
@@ -40,17 +40,22 @@ else:
             print(f"Diff: {diff=}\n{expected=}\n{actual=}")
             raise AssertionError(f"Results not within tolerance {tolerance}")
 
-    @unittest.skip(
-        "Fails with 'NCCL Error 7: NCCL operation in progress' on recent torch"
-        " nightlies"
-    )
-    @skipUnless(
-        torch.cuda.is_available() and torch.cuda.device_count() >= 2,
-        "2 CUDA devices are required for this test",
-    )
-    class QuantizedAllReduceTest(MultiPgBaseTest):
-        BACKEND = "nccl"
-        WORLD_SIZE = 2
+    class QuantizedCollectiveTestMixin:
+        """
+        Device-agnostic body of the quantized collective tests.
+
+        Not a ``TestCase`` itself, so it is never collected directly. Concrete
+        subclasses mix it with :class:`MultiPgBaseTest` and set ``BACKEND`` and
+        ``DEVICE_TYPE`` to the accelerator under test.
+        """
+
+        DEVICE_TYPE = "cuda"
+
+        # Provided by MultiPgBaseTest.
+        WORLD_SIZE: int
+        pg_pool: List[ProcessGroup]
+        executor: ThreadPoolExecutor
+        _collect: Callable[[List[Future[object]]], None]
 
         def _run_parallel_collectives(
             self, collective: Callable[[ProcessGroup, int, str], None]
@@ -58,7 +63,7 @@ else:
             futures = []
             for rank in range(self.WORLD_SIZE):
                 pg = self.pg_pool[rank]
-                device = f"cuda:{rank}"
+                device = f"{self.DEVICE_TYPE}:{rank}"
                 fut = self.executor.submit(collective, pg, rank, device)
                 futures.append(fut)
 
@@ -75,7 +80,7 @@ else:
             reduce_op: ReduceOp,
             dtype: torch.dtype,
         ) -> None:
-            cuda.set_device(device)
+            torch.accelerator.set_device_index(device)
             inp = (
                 torch.rand(
                     tensors_num * tensor_size,
@@ -114,7 +119,7 @@ else:
             reduce_op: ReduceOp,
             dtype: torch.dtype,
         ) -> None:
-            cuda.set_device(device)
+            torch.accelerator.set_device_index(device)
             inp = (
                 torch.rand(
                     tensors_num * tensor_size,
@@ -211,3 +216,25 @@ else:
                     dtype,
                 )
             )
+
+    @unittest.skip(
+        "Fails with 'NCCL Error 7: NCCL operation in progress' on recent torch"
+        " nightlies"
+    )
+    @skipUnless(
+        torch.cuda.is_available() and torch.cuda.device_count() >= 2,
+        "2 CUDA devices are required for this test",
+    )
+    class QuantizedAllReduceTest(QuantizedCollectiveTestMixin, MultiPgBaseTest):
+        BACKEND = "nccl"
+        WORLD_SIZE = 2
+        DEVICE_TYPE = "cuda"
+
+    @skipUnless(
+        torch.xpu.is_available() and torch.xpu.device_count() >= 2,
+        "2 XPU devices are required for this test",
+    )
+    class QuantizedAllReduceXcclTest(QuantizedCollectiveTestMixin, MultiPgBaseTest):
+        BACKEND = "xccl"
+        WORLD_SIZE = 2
+        DEVICE_TYPE = "xpu"

--- a/torchft/diloco_regression_test.py
+++ b/torchft/diloco_regression_test.py
@@ -293,7 +293,7 @@ def mock_diloco_train_loop(
 class DiLoCoMockedUpdateTest(TestCase):
     @parameterized.expand(
         [
-            # Format: (use_cuda, n_fragments, fragment_sync_delay, fragment_update_alpha)
+            # Format: (use_accelerator, n_fragments, fragment_sync_delay, fragment_update_alpha)
             (False, 2, 0, 0),  # 2 fragments, no delay, 0% mixing
             (False, 2, 0, 0.5),  # 2 fragments, no delay, 50% mixing
             (False, 2, 0, 1),  # 2 fragments, no delay, 100% mixing
@@ -304,7 +304,7 @@ class DiLoCoMockedUpdateTest(TestCase):
     )
     def test_diloco_mocked_updates(
         self,
-        use_cuda: bool,
+        use_accelerator: bool,
         n_fragments: int,
         fragment_sync_delay: int,
         fragment_update_alpha: float,
@@ -316,9 +316,9 @@ class DiLoCoMockedUpdateTest(TestCase):
         - fragment_sync_delay: Delay between preparing and syncing fragments (0 or 1)
         - fragment_update_alpha: Controls mixing of local and global parameters (0.0, 0.5, or 1.0)
         """
-        # Skip the test if use_cuda is True and there are not enough GPUs
-        if use_cuda and torch.cuda.device_count() < 2:
-            self.skipTest("Not enough GPUs for CUDA test")
+        # Skip if an accelerator was requested but not enough devices exist
+        if use_accelerator and torch.accelerator.device_count() < 2:
+            self.skipTest("Not enough accelerator devices for this test")
         if sys.platform == "darwin":
             self.skipTest("not reliable on mac")
 
@@ -343,7 +343,7 @@ class DiLoCoMockedUpdateTest(TestCase):
                     lighthouse_address=lighthouse.address(),
                     event_injector=event_injector,
                     train_loop=mock_diloco_train_loop,
-                    use_cuda=use_cuda,
+                    use_accelerator=use_accelerator,
                     train_loop_args={
                         "quorum_barrier": quorum_barrier,
                         "n_fragments": n_fragments,
@@ -383,13 +383,13 @@ class DiLoCoMockedUpdateTest(TestCase):
 
     @parameterized.expand(
         [
-            # Format: (use_cuda, n_fragments, fragment_sync_delay, fragment_update_alpha)
+            # Format: (use_accelerator, n_fragments, fragment_sync_delay, fragment_update_alpha)
             (False, 2, 0, 0),  # 2 fragments, no delay, 0% mixing
         ]
     )
     def test_diloco_mocked_failure_recovery(
         self,
-        use_cuda: bool,
+        use_accelerator: bool,
         n_fragments: int,
         fragment_sync_delay: int,
         fragment_update_alpha: float,
@@ -399,9 +399,9 @@ class DiLoCoMockedUpdateTest(TestCase):
         One replica is set to fail at step 2, and the test verifies that
         the system recovers and parameters are correctly synchronized after recovery.
         """
-        # Skip the test if use_cuda is True and there are not enough GPUs
-        if use_cuda and torch.cuda.device_count() < 2:
-            self.skipTest("Not enough GPUs for CUDA test")
+        # Skip if an accelerator was requested but not enough devices exist
+        if use_accelerator and torch.accelerator.device_count() < 2:
+            self.skipTest("Not enough accelerator devices for this test")
         if sys.platform == "darwin":
             self.skipTest("not reliable on mac")
 
@@ -429,7 +429,7 @@ class DiLoCoMockedUpdateTest(TestCase):
                     lighthouse_address=lighthouse.address(),
                     event_injector=event_injector,
                     train_loop=mock_diloco_train_loop,
-                    use_cuda=use_cuda,
+                    use_accelerator=use_accelerator,
                     train_loop_args={
                         "n_fragments": n_fragments,
                         "model_state_dict": model_state_dict,

--- a/torchft/local_sgd_integ_test.py
+++ b/torchft/local_sgd_integ_test.py
@@ -30,13 +30,9 @@ from torchft.manager import Manager
 from torchft.manager_integ_test import (
     EventInjector,
     EventInjectorEvent,
+    make_pg_for_device,
     MyModel,
     Runner,
-)
-from torchft.process_group import (
-    FakeProcessGroupWrapper,
-    ProcessGroupBabyNCCL,
-    ProcessGroupGloo,
 )
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -64,10 +60,7 @@ def local_sgd_train_loop(
 
         print(f"worker {runner.replica_id=} {rank=} {runner.world_size=} starting")
 
-        if device.type == "cuda":
-            pg = ProcessGroupBabyNCCL()
-        else:
-            pg = ProcessGroupGloo()
+        pg = make_pg_for_device(device)
         manager = Manager(
             pg=pg,
             min_replica_size=2,
@@ -172,18 +165,18 @@ def assert_equal_global_state(
 
 
 class LocalSGDIntegTest(TestCase):
-    # TODO: race condition due to using NCCL in threads causes manager allreduce to sometimes not be correct
-    # Because of that the test is disabled for cuda
+    # TODO: race condition due to using NCCL/XCCL in threads causes manager allreduce
+    # to sometimes not be correct. Because of that the accelerator variants are disabled.
     @parameterized.expand(
         [
             # (True,),
             (False,),
         ]
     )
-    def test_local_sgd_recovery(self, use_cuda: bool) -> None:
-        # Skip the test if use_cuda is True and there are not enough GPUs
-        if use_cuda and torch.cuda.device_count() < 2:
-            self.skipTest("Not enough GPUs for CUDA test")
+    def test_local_sgd_recovery(self, use_accelerator: bool) -> None:
+        # Skip if an accelerator was requested but not enough devices exist
+        if use_accelerator and torch.accelerator.device_count() < 2:
+            self.skipTest("Not enough accelerator devices for this test")
         if sys.platform == "darwin":
             self.skipTest("not reliable on mac")
 
@@ -207,7 +200,7 @@ class LocalSGDIntegTest(TestCase):
                     lighthouse_address=lighthouse.address(),
                     event_injector=event_injector,
                     train_loop=local_sgd_train_loop,
-                    use_cuda=use_cuda,
+                    use_accelerator=use_accelerator,
                     manager_args={
                         "use_async_quorum": False,
                     },
@@ -244,10 +237,10 @@ class LocalSGDIntegTest(TestCase):
             (False,),
         ]
     )
-    def test_diloco_healthy(self, use_cuda: bool) -> None:
-        # Skip the test if use_cuda is True and there are not enough GPUs
-        if use_cuda and torch.cuda.device_count() < 2:
-            self.skipTest("Not enough GPUs for CUDA test")
+    def test_diloco_healthy(self, use_accelerator: bool) -> None:
+        # Skip if an accelerator was requested but not enough devices exist
+        if use_accelerator and torch.accelerator.device_count() < 2:
+            self.skipTest("Not enough accelerator devices for this test")
         if sys.platform == "darwin":
             self.skipTest("not reliable on mac")
 
@@ -268,7 +261,7 @@ class LocalSGDIntegTest(TestCase):
                     lighthouse_address=lighthouse.address(),
                     event_injector=event_injector,
                     train_loop=diloco_train_loop,
-                    use_cuda=use_cuda,
+                    use_accelerator=use_accelerator,
                     train_loop_args={
                         "model_state_dict": m.state_dict(),
                     },
@@ -298,10 +291,10 @@ class LocalSGDIntegTest(TestCase):
             (False,),
         ]
     )
-    def test_diloco_recovery(self, use_cuda: bool) -> None:
-        # Skip the test if use_cuda is True and there are not enough GPUs
-        if use_cuda and torch.cuda.device_count() < 2:
-            self.skipTest("Not enough GPUs for CUDA test")
+    def test_diloco_recovery(self, use_accelerator: bool) -> None:
+        # Skip if an accelerator was requested but not enough devices exist
+        if use_accelerator and torch.accelerator.device_count() < 2:
+            self.skipTest("Not enough accelerator devices for this test")
         if sys.platform == "darwin":
             self.skipTest("not reliable on mac")
 
@@ -379,10 +372,10 @@ class LocalSGDIntegTest(TestCase):
             (False,),
         ]
     )
-    def test_streaming_diloco_recovery(self, use_cuda: bool) -> None:
-        # Skip the test if use_cuda is True and there are not enough GPUs
-        if use_cuda and torch.cuda.device_count() < 2:
-            self.skipTest("Not enough GPUs for CUDA test")
+    def test_streaming_diloco_recovery(self, use_accelerator: bool) -> None:
+        # Skip if an accelerator was requested but not enough devices exist
+        if use_accelerator and torch.accelerator.device_count() < 2:
+            self.skipTest("Not enough accelerator devices for this test")
         if sys.platform == "darwin":
             self.skipTest("not reliable on mac")
 
@@ -443,8 +436,8 @@ class LocalSGDIntegTest(TestCase):
         self.assertEqual(event_injectors[1].count[EventInjectorEvent.Failure], 1)
 
     CONFIG: list[tuple[bool, int, int, float]] = [
-        (use_cuda, n_fragments, fragment_sync_delay, alpha)
-        for use_cuda in [False]
+        (use_accelerator, n_fragments, fragment_sync_delay, alpha)
+        for use_accelerator in [False]
         for n_fragments in [1, 2]
         for fragment_sync_delay in [0, 1]
         for alpha in [0.0, 0.5, 1.0]
@@ -454,11 +447,15 @@ class LocalSGDIntegTest(TestCase):
     @skipIf(sys.platform == "darwin", "not reliable on mac")
     @parameterized.expand(CONFIG)
     def test_streaming_diloco_upscale(
-        self, use_cuda: bool, n_fragments: int, fragment_sync_delay: int, alpha: float
+        self,
+        use_accelerator: bool,
+        n_fragments: int,
+        fragment_sync_delay: int,
+        alpha: float,
     ) -> None:
-        # Skip the test if use_cuda is True and there are not enough GPUs
-        if use_cuda and torch.cuda.device_count() < 2:
-            self.skipTest("Not enough GPUs for CUDA test")
+        # Skip if an accelerator was requested but not enough devices exist
+        if use_accelerator and torch.accelerator.device_count() < 2:
+            self.skipTest("Not enough accelerator devices for this test")
         if sys.platform == "darwin":
             self.skipTest("not reliable on mac")
 
@@ -532,11 +529,15 @@ class LocalSGDIntegTest(TestCase):
     @skipIf(sys.platform == "darwin", "not reliable on mac")
     @parameterized.expand(CONFIG)
     def test_streaming_diloco_commit_failure(
-        self, use_cuda: bool, n_fragments: int, fragment_sync_delay: int, alpha: float
+        self,
+        use_accelerator: bool,
+        n_fragments: int,
+        fragment_sync_delay: int,
+        alpha: float,
     ) -> None:
-        # Skip the test if use_cuda is True and there are not enough GPUs
-        if use_cuda and torch.cuda.device_count() < 2:
-            self.skipTest("Not enough GPUs for CUDA test")
+        # Skip if an accelerator was requested but not enough devices exist
+        if use_accelerator and torch.accelerator.device_count() < 2:
+            self.skipTest("Not enough accelerator devices for this test")
         if sys.platform == "darwin":
             self.skipTest("not reliable on mac")
 

--- a/torchft/manager_integ_test.py
+++ b/torchft/manager_integ_test.py
@@ -43,7 +43,9 @@ from torchft.manager import Manager
 from torchft.optim import OptimizerWrapper
 from torchft.process_group import (
     FakeProcessGroupWrapper,
+    ProcessGroup,
     ProcessGroupBabyNCCL,
+    ProcessGroupBabyXCCL,
     ProcessGroupGloo,
 )
 
@@ -60,6 +62,19 @@ logging.basicConfig(level=logging.INFO)
 logger: logging.Logger = logging.getLogger(__name__)
 
 INIT_LOCK: threading.Lock = threading.Lock()
+
+
+def make_pg_for_device(device: torch.device) -> ProcessGroup:
+    """
+    Returns the process group matching the device's accelerator, so the same
+    train loops run on CUDA (NCCL), XPU (XCCL) and CPU (Gloo).
+    """
+    if device.type == "cuda":
+        return ProcessGroupBabyNCCL()
+    elif device.type == "xpu":
+        return ProcessGroupBabyXCCL()
+    else:
+        return ProcessGroupGloo()
 
 
 class MyModel(nn.Module):
@@ -200,7 +215,7 @@ class Runner:
     event_injector: EventInjector
     train_loop: TrainLoop[object]
 
-    use_cuda: bool = False
+    use_accelerator: bool = False
     world_size: int = 1
     attempts: int = 3
     manager_args: Dict[str, object] = field(default_factory=dict)
@@ -219,13 +234,15 @@ class Runner:
         ) as executor:
             futures = []
             for rank in range(self.world_size):
-                if self.use_cuda:
-                    num_cuda_devices = torch.cuda.device_count()
-                    assert num_cuda_devices >= self.num_replicas
+                if self.use_accelerator:
+                    acc = torch.accelerator.current_accelerator()
+                    assert acc is not None, "no accelerator available"
+                    num_devices = torch.accelerator.device_count()
+                    assert num_devices >= self.num_replicas
                     device_index = (
-                        num_cuda_devices // self.num_replicas
+                        num_devices // self.num_replicas
                     ) * self.replica_id + rank
-                    device = torch.device(f"cuda:{device_index}")
+                    device = torch.device(f"{acc.type}:{device_index}")
                 else:
                     device = torch.device("cpu")
 
@@ -568,14 +585,14 @@ class ManagerIntegTest(TestCase):
 
     @parameterized.expand(
         [
-            (True,),  # Test with CUDA
-            (False,),  # Test without CUDA (CPU)
+            (True,),  # Test with an accelerator (CUDA or XPU)
+            (False,),  # Test without an accelerator (CPU)
         ]
     )
-    def test_manager_allreduce(self, use_cuda: bool) -> None:
-        # Skip the test if use_cuda is True and there are not enough GPUs
-        if use_cuda and torch.cuda.device_count() < 2:
-            self.skipTest("Not enough GPUs for CUDA test")
+    def test_manager_allreduce(self, use_accelerator: bool) -> None:
+        # Skip if an accelerator was requested but not enough devices exist
+        if use_accelerator and torch.accelerator.device_count() < 2:
+            self.skipTest("Not enough accelerator devices for this test")
 
         # manager supports allreduce but we found an issue where the future callback is getting called
         # before the allreduce is complete. This test is to ensure that the callback has stream synchronization
@@ -595,7 +612,7 @@ class ManagerIntegTest(TestCase):
                     lighthouse_address=lighthouse.address(),
                     event_injector=event_injector,
                     train_loop=all_reduce_callback,
-                    use_cuda=use_cuda,
+                    use_accelerator=use_accelerator,
                 )
                 futures.append(executor.submit(runner.run_replica))
 
@@ -630,7 +647,7 @@ class ManagerIntegTest(TestCase):
             for replica_id in range(num_replicas):
                 event_injector = EventInjector()
                 runner = Runner(
-                    use_cuda=True,
+                    use_accelerator=True,
                     replica_id=replica_id,
                     num_replicas=num_replicas,
                     lighthouse_address=lighthouse.address(),
@@ -669,7 +686,7 @@ class ManagerIntegTest(TestCase):
         with ThreadPoolExecutor(max_workers=num_replicas) as executor:
             for replica_id, event_injector in zip(range(num_replicas), event_injectors):
                 runner = Runner(
-                    use_cuda=True,
+                    use_accelerator=True,
                     replica_id=replica_id,
                     num_replicas=num_replicas,
                     lighthouse_address=lighthouse.address(),
@@ -780,10 +797,7 @@ def all_reduce_callback(
     with ExitStack() as stack:
         print(f"worker {runner.replica_id=} {rank=} {runner.world_size=} starting")
 
-        if device.type == "cuda":
-            pg = ProcessGroupBabyNCCL()
-        else:
-            pg = ProcessGroupGloo()
+        pg = make_pg_for_device(device)
         manager = Manager(
             pg=pg,
             min_replica_size=2,

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -1443,7 +1443,9 @@ def _maybe_share_tensors(
         for t in tensor:
             _maybe_share_tensors(t)
     elif isinstance(tensor, torch.Tensor):
-        if not tensor.is_shared():
+        # Device tensors (CUDA, XPU) are already shared across processes
+        # Only CPU tensors need explicit share_memory_() call
+        if not tensor.is_shared() and tensor.device.type == "cpu":
             tensor.share_memory_()
     else:
         raise TypeError(f"expected tensor or list but got {type(tensor)}")

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -43,10 +43,12 @@ from torchft.process_group import (
     ProcessGroup,
     ProcessGroupBabyGloo,
     ProcessGroupBabyNCCL,
+    ProcessGroupBabyXCCL,
     ProcessGroupDummy,
     ProcessGroupGloo,
     ProcessGroupNCCL,
     ProcessGroupWrapper,
+    ProcessGroupXCCL,
 )
 from torchft.work import _DummyWork
 
@@ -321,7 +323,7 @@ def run_broadcast_one_test(pg: ProcessGroup, rank: int, tensor: torch.Tensor) ->
 def run_barrier_test(pg: ProcessGroup, rank: int, tensor: torch.Tensor) -> None:
     """Test barrier collective operation."""
     opts = BarrierOptions()
-    if tensor.is_cuda:
+    if tensor.is_cuda or tensor.is_xpu:
         device_id = tensor.device.index
         opts.device_ids = [device_id]
     barrier_work = pg.barrier(opts)
@@ -570,6 +572,34 @@ class ProcessGroupTest(TestCase):
         torch.cuda.synchronize()
 
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @skipUnless(torch.xpu.is_available(), "needs XPU")
+    def test_xccl_apis(self) -> None:
+        store = TCPStore(
+            host_name="localhost", port=0, is_master=True, wait_for_workers=False
+        )
+        device = "xpu"
+
+        store_addr = f"localhost:{store.port}/prefix"
+        pg = ProcessGroupXCCL()
+        pg.configure(store_addr, "0", 0, 1)
+
+        self.assertEqual(pg.size(), 1)
+
+        _test_pg(pg, torch.tensor([2], device=device))
+
+        m = nn.Linear(3, 4).to(device)
+        m = torch.nn.parallel.DistributedDataParallel(m, process_group=pg)
+        m(torch.rand(2, 3, device=device))
+
+        # reconfigure
+        store_addr = f"localhost:{store.port}/prefix2"
+        pg.configure(store_addr, "0", 0, 1)
+
+        _test_pg(pg, torch.tensor([2], device=device))
+
+        torch.xpu.synchronize()
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     @skipUnless(
         torch.cuda.is_available() and torch.cuda.nccl.version() >= (2, 25),
         "needs NCCL >=2.25",
@@ -610,6 +640,23 @@ class ProcessGroupTest(TestCase):
         del store
 
         pg = ProcessGroupNCCL(timeout=timedelta(seconds=0.01))
+
+        with self.assertRaisesRegex(RuntimeError, "timed out after 10ms"):
+            pg.configure(store_addr, "0", 0, 2)
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator
+    @skipUnless(
+        torch.xpu.is_available(),
+        "needs XPU",
+    )
+    def test_xccl_init_timeout(self) -> None:
+        store = TCPStore(
+            host_name="localhost", port=0, is_master=True, wait_for_workers=False
+        )
+        store_addr = f"localhost:{store.port}/prefix"
+        del store
+
+        pg = ProcessGroupXCCL(timeout=timedelta(seconds=0.01))
 
         with self.assertRaisesRegex(RuntimeError, "timed out after 10ms"):
             pg.configure(store_addr, "0", 0, 2)
@@ -715,6 +762,41 @@ class ProcessGroupTest(TestCase):
             a.shutdown()
             torch.cuda.synchronize()
             torch.cuda.empty_cache()
+
+        t = torch.zeros(10)
+        with self.assertRaisesRegex(OSError, "handle is closed"):
+            a.allreduce([t], AllreduceOptions()).wait()
+
+    # pyre-fixme[56]: Pyre was not able to infer the type of argument
+    @skipUnless(torch.xpu.is_available(), "needs XPU")
+    @skipIf(True, "PyTorch XPU multiprocessing reductions not yet supported - see https://github.com/pytorch/pytorch/issues")
+    def test_baby_xccl_apis(self) -> None:
+        # set to 1 if more than >=2 xpus
+        device_id = 1 % torch.xpu.device_count()
+        torch.xpu.set_device(device_id)
+
+        store = TCPStore(
+            host_name="localhost", port=0, is_master=True, wait_for_workers=False
+        )
+
+        store_addr = f"localhost:{store.port}/prefix"
+
+        a = ProcessGroupBabyXCCL(timeout=timedelta(seconds=10))
+        try:
+            a.configure(store_addr, "0", 0, 1)
+
+            _test_pg(a, torch.randn((2, 3), device="xpu"))
+
+            torch.xpu.synchronize()
+
+            # force collection to ensure no BabyWork objects remain
+            gc.collect()
+
+            self.assertEqual(a.num_active_work(), 0)
+        finally:
+            a.shutdown()
+            torch.xpu.synchronize()
+            torch.xpu.empty_cache()
 
         t = torch.zeros(10)
         with self.assertRaisesRegex(OSError, "handle is closed"):
@@ -893,6 +975,10 @@ class MultiPgBaseTest(TestCase):
             return ProcessGroupNCCL(timeout=timedelta(seconds=10))
         elif backend == "baby_nccl":
             return ProcessGroupBabyNCCL(timeout=timedelta(seconds=10))
+        elif backend == "xccl":
+            return ProcessGroupXCCL(timeout=timedelta(seconds=10))
+        elif backend == "baby_xccl":
+            return ProcessGroupBabyXCCL(timeout=timedelta(seconds=10))
         elif backend == "dummy":
             return ProcessGroupDummy(0, 1)
         else:
@@ -909,8 +995,10 @@ class MultiPgBaseTest(TestCase):
         for rank in range(self.WORLD_SIZE):
             pg = self.pg_pool[rank]
             # Each worker calls `func(pg=pg, rank=rank, tensor=tensor, *args, **kwargs)`
-            if "cuda" in device:
+            if device == "cuda":
                 device = f"cuda:{rank}"
+            elif device == "xpu":
+                device = f"xpu:{rank}"
             tensor = torch.tensor([rank + 1], device=device)
 
             fut = self.executor.submit(func, pg, rank, tensor)
@@ -943,6 +1031,10 @@ class MultiPgBaseTest(TestCase):
                 torch.cuda.set_device(rank)
                 # Use a separate stream to avoid deadlocks between threads.
                 torch.cuda.set_stream(torch.cuda.Stream())
+            elif dev == "xpu":
+                torch.xpu.set_device(rank)
+                # Use a separate stream to avoid deadlocks between threads.
+                torch.xpu.set_stream(torch.xpu.Stream())
 
             fault_rank = self.WORLD_SIZE - 1
             test = _COLLECTIVE_TO_FUNC[collective]
@@ -1067,3 +1159,36 @@ class NormalNcclMultiPgTest(MultiPgBaseTest):
     @parameterized.expand(_ALL_COLLECTIVES)
     def test_collective_with_resiliency(self, collective: str) -> None:
         self._run_with_resiliency(collective, device="cuda")
+
+
+@skipUnless(
+    torch.xpu.is_available() and torch.xpu.device_count() >= 2, "needs 2 XPU devices"
+)
+class BabyXcclMultiPgTest(MultiPgBaseTest):
+    BACKEND = "baby_xccl"
+    WORLD_SIZE = 2
+
+    @parameterized.expand(_ALL_COLLECTIVES)
+    def test_collective(self, collective: str) -> None:
+        self._run_parallel(collective, device="xpu")
+
+    # @parameterized.expand(_ALL_COLLECTIVES)
+    # def test_collective_with_resiliency(self, collective: str) -> None:
+    #    self._run_with_resiliency(collective, device="xpu")
+
+
+@skipUnless(
+    torch.xpu.is_available() and torch.xpu.device_count() >= 2,
+    "needs 2 XPU devices",
+)
+class NormalXcclMultiPgTest(MultiPgBaseTest):
+    BACKEND = "xccl"
+    WORLD_SIZE = 2
+
+    @parameterized.expand(_ALL_COLLECTIVES)
+    def test_collective(self, collective: str) -> None:
+        self._run_parallel(collective, device="xpu")
+
+    @parameterized.expand(_ALL_COLLECTIVES)
+    def test_collective_with_resiliency(self, collective: str) -> None:
+        self._run_with_resiliency(collective, device="xpu")

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -769,7 +769,11 @@ class ProcessGroupTest(TestCase):
 
     # pyre-fixme[56]: Pyre was not able to infer the type of argument
     @skipUnless(torch.xpu.is_available(), "needs XPU")
-    @skipIf(True, "PyTorch XPU multiprocessing reductions not yet supported - see https://github.com/pytorch/pytorch/issues")
+    @skipIf(
+        True,
+        "PyTorch XPU multiprocessing reductions not yet supported - see "
+        "https://github.com/pytorch/pytorch/issues/170636",
+    )
     def test_baby_xccl_apis(self) -> None:
         # set to 1 if more than >=2 xpus
         device_id = 1 % torch.xpu.device_count()
@@ -941,7 +945,11 @@ class MultiPgBaseTest(TestCase):
 
         def init_pg(rank: int) -> ProcessGroup:
             if torch.accelerator.is_available():
-                torch.accelerator.set_device_idx(rank)
+                # CPU backends run with a WORLD_SIZE larger than the accelerator
+                # count, so wrap around instead of erroring out.
+                torch.accelerator.set_device_idx(
+                    rank % torch.accelerator.device_count()
+                )
             pg = cls._create_pg(cls.BACKEND)
             pg.configure(cls.store_addr, "0", rank, cls.WORLD_SIZE)
             return pg
@@ -995,11 +1003,12 @@ class MultiPgBaseTest(TestCase):
         for rank in range(self.WORLD_SIZE):
             pg = self.pg_pool[rank]
             # Each worker calls `func(pg=pg, rank=rank, tensor=tensor, *args, **kwargs)`
-            if device == "cuda":
-                device = f"cuda:{rank}"
-            elif device == "xpu":
-                device = f"xpu:{rank}"
-            tensor = torch.tensor([rank + 1], device=device)
+            rank_device = device
+            if "cuda" in device:
+                rank_device = f"cuda:{rank}"
+            elif "xpu" in device:
+                rank_device = f"xpu:{rank}"
+            tensor = torch.tensor([rank + 1], device=rank_device)
 
             fut = self.executor.submit(func, pg, rank, tensor)
             futures.append(fut)
@@ -1027,11 +1036,11 @@ class MultiPgBaseTest(TestCase):
         def worker(pg: ProcessGroup, rank: int, dev: str) -> str:
             pg.set_timeout(timedelta(seconds=30))
 
-            if dev == "cuda":
+            if "cuda" in dev:
                 torch.cuda.set_device(rank)
                 # Use a separate stream to avoid deadlocks between threads.
                 torch.cuda.set_stream(torch.cuda.Stream())
-            elif dev == "xpu":
+            elif "xpu" in dev:
                 torch.xpu.set_device(rank)
                 # Use a separate stream to avoid deadlocks between threads.
                 torch.xpu.set_stream(torch.xpu.Stream())

--- a/torchft/quantization_test.py
+++ b/torchft/quantization_test.py
@@ -13,7 +13,12 @@ from torchft import _test_utils
 
 torch.set_printoptions(precision=4, sci_mode=False)
 
-DEVICE = "cuda"
+# Resolved per-accelerator so the same test body covers CUDA and XPU.
+DEVICE: str = (
+    str(torch.accelerator.current_accelerator())
+    if torch.accelerator.is_available()
+    else "cpu"
+)
 
 try:
     # pyre-fixme[21]: Could not find a module corresponding to import `triton`
@@ -22,14 +27,15 @@ except ImportError:
     pass
 else:
     from torchft.quantization import (
+        _supports_native_fp8,
         fused_dequantize_from_fp8,
         fused_quantize_into_fp8,
         fused_reduce_fp8,
     )
 
     @skipUnless(
-        torch.cuda.is_available(),
-        "CUDA is required for this test",
+        torch.accelerator.is_available(),
+        "An accelerator (CUDA or XPU) is required for this test",
     )
     class QuantizationTest(TestCase):
         def run_test(
@@ -46,7 +52,7 @@ else:
                 torch.rand(
                     tensors_num * tensor_size,
                     dtype=type,
-                    device="cuda",
+                    device=DEVICE,
                 )
                 * multiplier
             )
@@ -128,3 +134,44 @@ else:
                 reduce_op=reduce_op,
                 type=type,
             )
+
+    @skipUnless(torch.xpu.is_available(), "XPU is required for this test")
+    class QuantizationXpuTest(TestCase):
+        def test_no_native_fp8_on_xpu(self) -> None:
+            """XPU has no native FP8, so the kernels must take the int8 path."""
+            self.assertFalse(_supports_native_fp8())
+
+        @parameterized.expand(
+            [
+                (torch.float32,),
+                (torch.float16,),
+                (torch.bfloat16,),
+            ]
+        )
+        def test_quantize_dequantize_roundtrip(self, dtype: torch.dtype) -> None:
+            """The int8 fallback round-trips XPU tensors within tolerance."""
+            world_size = 2
+            tensor_size = 512
+            inp = torch.rand(2 * tensor_size, dtype=dtype, device="xpu")
+
+            for split in _test_utils.gen_splits(inp, tensor_size):
+                inputs = inp.clone()
+                outputs = torch.empty_like(inputs)
+
+                tensors_in = [
+                    i.view(*s) for s, i in zip(split, torch.split(inputs, tensor_size))
+                ]
+                tensors_out = [
+                    o.view(*s) for s, o in zip(split, torch.split(outputs, tensor_size))
+                ]
+
+                quant = fused_quantize_into_fp8(tensors_in, world_size)
+                fused_dequantize_from_fp8(tensors_out, quant, world_size)
+
+                torch.xpu.synchronize()
+
+                self.assertFalse(_test_utils.any_nan(tensors_out))
+                diff = torch.abs(
+                    (inputs - outputs).div(inputs.to(torch.float32) + 0.0000001)
+                )
+                self.assertLessEqual(diff.mean().item(), 0.05)

--- a/torchft/utils_test.py
+++ b/torchft/utils_test.py
@@ -1,0 +1,74 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from contextlib import nullcontext
+from unittest import skipUnless, TestCase
+
+import torch
+from torchft.utils import get_stream_context, record_event, synchronize
+
+
+class UtilsTest(TestCase):
+    def test_get_stream_context_none(self) -> None:
+        """A None stream yields a nullcontext regardless of accelerator."""
+        ctx = get_stream_context(None)
+        self.assertIsInstance(ctx, nullcontext)
+
+        with ctx:
+            pass
+
+    @skipUnless(torch.accelerator.is_available(), "needs an accelerator")
+    def test_get_stream_context_accelerator(self) -> None:
+        """A real stream yields a usable device stream context."""
+        acc = torch.accelerator.current_accelerator()
+        stream = torch.Stream(acc)
+
+        with get_stream_context(stream):
+            t = torch.ones(4, device=acc) * 2
+            self.assertEqual(t.sum().item(), 8)
+
+        synchronize()
+
+    def test_synchronize_without_accelerator(self) -> None:
+        """synchronize() is a no-op rather than an error when no accelerator exists."""
+        if torch.accelerator.is_available():
+            self.skipTest("accelerator present; covered by the accelerator test")
+
+        synchronize()
+
+    @skipUnless(torch.accelerator.is_available(), "needs an accelerator")
+    def test_record_event(self) -> None:
+        """record_event() records on the current stream for the active accelerator."""
+        record_event()
+        synchronize()
+
+
+@skipUnless(torch.cuda.is_available(), "needs CUDA")
+class UtilsCudaTest(TestCase):
+    def test_get_stream_context_returns_cuda_context(self) -> None:
+        stream = torch.Stream(torch.device("cuda"))
+        ctx = get_stream_context(stream)
+        self.assertIsInstance(ctx, torch.cuda.StreamContext)
+
+
+@skipUnless(torch.xpu.is_available(), "needs XPU")
+class UtilsXpuTest(TestCase):
+    def test_get_stream_context_returns_xpu_context(self) -> None:
+        stream = torch.Stream(torch.device("xpu"))
+        ctx = get_stream_context(stream)
+        self.assertIsInstance(ctx, torch.xpu.StreamContext)
+
+    def test_stream_context_runs_work_on_xpu(self) -> None:
+        stream = torch.Stream(torch.device("xpu"))
+
+        with get_stream_context(stream):
+            t = torch.arange(8, device="xpu", dtype=torch.float32)
+            out = t * 3
+            # synchronize() waits on the current stream, so it has to run
+            # inside the context while `stream` is still current.
+            synchronize()
+
+        self.assertEqual(out.sum().item(), 84.0)


### PR DESCRIPTION
Test script changes for #327 (landed as 05ec72e), per that PR's test plan. Adds XPU coverage across the unit and integration test suites using torch.accelerator, so the same tests run on CUDA and XPU.

 Also adds torchft/utils_test.py covering get_stream_context / record_event / synchronize from #260.
One non-test change: _maybe_share_tensors now only calls share_memory_() on CPU tensors — device tensors are already shared, and calling it on an XPU tensor fails. Required for pg_transport_test.py to pass on XPU. Validated on Intel Arc Pro B60 Graphics.
