### PR TITLE
Add Intel XPU (XCCL) support across torchft 

### DIFF
--- a/torchft/checkpointing/http_transport.py
+++ b/torchft/checkpointing/http_transport.py
@@ -10,7 +10,7 @@ import threading
 import time
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 from datetime import timedelta
 from http.server import BaseHTTPRequestHandler
 from typing import cast, Generator, List, Optional, TypeVar
@@ -21,6 +21,7 @@ from torchft.checkpointing._rwlock import RWLock
 from torchft.checkpointing._serialization import _streaming_load, _streaming_save
 from torchft.checkpointing.transport import CheckpointTransport
 from torchft.http import _IPv6HTTPServer
+from torchft.utils import get_stream_context
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -55,8 +56,10 @@ class HTTPTransport(CheckpointTransport[T]):
         self._timeout = timeout
         self._state_dict: Optional[T] = None
         self._num_chunks = num_chunks
-        self._stream: Optional[torch.cuda.Stream] = (
-            torch.cuda.Stream() if torch.cuda.is_available() else None
+        self._stream: Optional[torch.Stream] = (
+            torch.Stream(torch.accelerator.current_accelerator())
+            if torch.accelerator.is_available()
+            else None
         )
 
         # staged checkpoint information
@@ -221,11 +224,7 @@ class HTTPTransport(CheckpointTransport[T]):
     ) -> None:
         values, spec = tree_flatten(state_dict)
 
-        with (
-            torch.cuda.stream(self._stream)
-            if self._stream is not None
-            else nullcontext()
-        ):
+        with get_stream_context(self._stream):
             with _time("transferring state_dict to CPU"):
                 values = _to_cpu(values, pin_memory=False)
                 if self._stream is not None:
@@ -270,7 +269,7 @@ def _to_cpu(values: List[T], pin_memory: bool) -> List[T]:
     out = []
     for v in values:
         if isinstance(v, torch.Tensor):
-            if v.device.type == "cuda":
+            if v.device.type in ("cuda", "xpu"):
                 if pin_memory:
                     cpu = torch.empty(*tuple(v.size()), dtype=v.dtype, pin_memory=True)
                     cpu.copy_(v, non_blocking=True)

--- a/torchft/checkpointing/pg_transport_bench.py
+++ b/torchft/checkpointing/pg_transport_bench.py
@@ -12,7 +12,7 @@ from datetime import timedelta
 import torch
 import torch.distributed as dist
 from torchft.checkpointing.pg_transport import _timeit, PGTransport
-from torchft.process_group import ProcessGroupBabyNCCL
+from torchft.process_group import ProcessGroupBabyNCCL, ProcessGroupBabyXCCL
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -46,12 +46,21 @@ def main(argv: list[str]) -> None:
     store_addr: str = f"localhost:{store.port}"
 
     def run(rank: int) -> None:
-        torch.cuda.set_device(rank)
+        if torch.accelerator.is_available():
+            torch.accelerator.set_device_index(rank)
 
         device = torch.device(DEVICE)
 
+        if device.type == "cuda":
+            torch.cuda.set_device(rank)
+        elif device.type == "xpu":
+            torch.xpu.set_device(rank)
+
         with _timeit("init_pg"):
-            pg = ProcessGroupBabyNCCL(timeout=timeout)
+            if device.type == "xpu":
+                pg = ProcessGroupBabyXCCL(timeout=timeout)
+            else:
+                pg = ProcessGroupBabyNCCL(timeout=timeout)
             pg.configure(store_addr=store_addr, replica_id="0", rank=rank, world_size=2)
 
             t = torch.zeros(10, device=device, dtype=torch.float32)

--- a/torchft/collectives.py
+++ b/torchft/collectives.py
@@ -5,13 +5,12 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import torch
 
 # pyre-ignore[21]: Could not find a module corresponding to import `triton`
 import triton
-from torch import cuda
 from torch.distributed import ReduceOp
 from torch.distributed.distributed_c10d import (
     AllgatherOptions,
@@ -30,6 +29,7 @@ from torchft.quantization import (
     fused_quantize_into_fp8,
     fused_reduce_fp8,
 )
+from torchft.utils import get_stream_context
 
 
 def _to_alltoall_options(
@@ -139,7 +139,7 @@ def allocate_reduce_scatter_output(
 class _QuantizedOpFuture(Future[list[torch.Tensor]]):
     def __init__(
         self,
-        sync_stream: cuda.Stream,
+        sync_stream: torch.Stream,
         keep_alive_tensors: list[torch.Tensor],
         return_tensors: list[torch.Tensor],
     ) -> None:
@@ -150,7 +150,7 @@ class _QuantizedOpFuture(Future[list[torch.Tensor]]):
 
     def wait(self) -> list[torch.Tensor]:
         # Wait for the synchronization to complete.
-        cuda.current_stream().wait_stream(self._sync_stream)
+        torch.accelerator.current_stream().wait_stream(self._sync_stream)
         # Clean up intermediate buffers.
         del self._keep_alive_tensors
         return self._return_tensors
@@ -161,7 +161,7 @@ def reduce_scatter_quantized(
     inputs: list[torch.Tensor],
     opts: ReduceScatterOptions | ReduceOp,
     process_group: "ProcessGroup",
-    sync_stream: cuda.Stream | None = None,
+    sync_stream: Optional[torch.Stream] = None,
 ) -> Work:
     """
     Performs a quantized reduce-scatter operation on a list of tensors.
@@ -228,13 +228,15 @@ def reduce_scatter_quantized(
     ]
 
     if sync_stream is None:
-        sync_stream = cuda.Stream()
+        # Create stream on the same device as the input tensors
+        device = inputs[0].device
+        sync_stream = torch.Stream(device=device)
 
     assert sync_stream is not None
     # Ensure that all operations are completed on the current stream
     # before proceeding with all-reduce
-    sync_stream.wait_stream(cuda.current_stream())
-    with cuda.stream(sync_stream):
+    sync_stream.wait_stream(torch.accelerator.current_stream())
+    with get_stream_context(sync_stream):
         # Quantize tensoers and compute their scales, all inlined in the
         # output tensor.
         quantized_inputs = fused_quantize_into_fp8(inputs, world_size)
@@ -263,7 +265,7 @@ def reduce_scatter_quantized(
                 reduce_outputs, \
                 reducescatter_opts
 
-            with torch.cuda.stream(sync_stream):
+            with get_stream_context(sync_stream):
                 # Setup stream dependency
                 fut.wait()
                 # Reduce chunks locally in higher precision after dequantization.
@@ -298,7 +300,7 @@ def allreduce_quantized(
     tensors: list[torch.Tensor],
     opts: AllreduceOptions | ReduceOp,
     process_group: "ProcessGroup",
-    sync_stream: cuda.Stream | None = None,
+    sync_stream: Optional[torch.Stream] = None,
 ) -> Work:
     """
     Performs a quantized all-reduce operation on a list of tensors.
@@ -352,13 +354,15 @@ def allreduce_quantized(
     world_size: int = process_group.size()
 
     if sync_stream is None:
-        sync_stream = cuda.Stream()
+        # Create stream on the same device as the input tensors
+        device = tensors[0].device
+        sync_stream = torch.Stream(device=device)
 
     assert sync_stream is not None
     # Ensure that all operations are completed on the current stream
     # before proceeding with all-reduce
-    sync_stream.wait_stream(cuda.current_stream())
-    with cuda.stream(sync_stream):
+    sync_stream.wait_stream(torch.accelerator.current_stream())
+    with get_stream_context(sync_stream):
         # Quantize tensoers and compute their scales, all inlined in the
         # output tensor.
         quantized_tensors: torch.Tensor = fused_quantize_into_fp8(tensors, world_size)
@@ -405,7 +409,7 @@ def allreduce_quantized(
             # Dequantize and copy to output buffer.
             nonlocal tensors, quantized_tensors, world_size, sync_stream
 
-            with torch.cuda.stream(sync_stream):
+            with get_stream_context(sync_stream):
                 # Setup stream dependency
                 fut.wait()
                 # Dequantize the result back to the original precision

--- a/torchft/collectives.py
+++ b/torchft/collectives.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from typing import TYPE_CHECKING, Optional
+from typing import Optional, TYPE_CHECKING
 
 import torch
 

--- a/torchft/local_sgd.py
+++ b/torchft/local_sgd.py
@@ -12,7 +12,6 @@ This module implements a fault tolerant version of LocalSGD and related methods.
 import logging
 import math
 import os
-from contextlib import nullcontext
 from types import TracebackType
 from typing import Any, Dict, List, Optional, Tuple, Type
 
@@ -22,6 +21,7 @@ from torch.distributed.distributed_c10d import Work
 from torch.distributed.tensor import DTensor
 from torch.utils.hooks import RemovableHandle
 from torchft.manager import Manager
+from torchft.utils import get_stream_context
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -212,12 +212,14 @@ class _StreamingDiLoCoFragment:
 
         # Stores pending all reduce
         self._allreduce_work: list[Work] = []
-        self._stream: Optional[torch.cuda.Stream] = (
-            torch.cuda.Stream() if torch.cuda.is_available() else None
+        self._stream: Optional[torch.Stream] = (
+            torch.Stream(torch.accelerator.current_accelerator())
+            if torch.accelerator.is_available()
+            else None
         )
 
         # Recorded on `_stream` to wait for allreduce to finish
-        self._stop_event: Optional[torch.cuda.Event] = None
+        self._stop_event: Optional[torch.Event] = None
 
         if bucket_cap_mb is not None:
             self.bucket_cap_mb = int(bucket_cap_mb * 1024 * 1024)
@@ -247,7 +249,7 @@ class _StreamingDiLoCoFragment:
             if (
                 self._pin_memory
                 and t.device == torch.device("cpu")
-                and torch.cuda.is_available()
+                and torch.accelerator.is_available()
             ):
                 t = t.pin_memory()
             self.original_parameters[name] = t
@@ -410,13 +412,9 @@ class _StreamingDiLoCoFragment:
 
         # Make sure tensors are available to `_stream`
         if self._stream is not None:
-            self._stream.wait_stream(torch.cuda.current_stream())
+            self._stream.wait_stream(torch.accelerator.current_stream())
 
-        with (
-            torch.cuda.stream(self._stream)
-            if self._stream is not None
-            else nullcontext()
-        ):
+        with get_stream_context(self._stream):
             self._average_grads()
 
     @torch.profiler.record_function("torchft::local_sgd::perform_sync")
@@ -428,16 +426,12 @@ class _StreamingDiLoCoFragment:
         # Waiting for an allreduce before it has been sent is currently not supported.
         assert len(self._allreduce_work) > 0
 
-        with (
-            torch.cuda.stream(self._stream)
-            if self._stream is not None
-            else nullcontext()
-        ):
+        with get_stream_context(self._stream):
             for work in self._allreduce_work:
                 work.wait()
 
             if self._stream is not None:
-                self._stop_event = torch.cuda.Event()
+                self._stop_event = torch.Event()
                 self._stop_event.record()
 
         self.wait()

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -459,7 +459,6 @@ class Manager:
                     [tensor],
                     pg_reduce_op,
                     self._pg,
-                    # pyre-fixme[6]: Expected `Optional[streams.Stream]` but got `_C.Stream`
                     torch.accelerator.current_stream(),
                 )
             else:

--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -664,6 +664,10 @@ class ProcessGroupGloo(ProcessGroupWrapper):
             pg._register_backend(
                 torch.device("cuda"), ProcessGroup.BackendType.GLOO, backend_class
             )
+        if torch.xpu.is_available():
+            pg._register_backend(
+                torch.device("xpu"), ProcessGroup.BackendType.GLOO, backend_class
+            )
         return pg
 
     def getBackendName(self) -> str:
@@ -728,10 +732,10 @@ class _WorkAcceleratorTimeout(Work):
                 if not self._work.wait():
                     return False
 
-            # Always use cuda stream for timeout to avoid ProcessGroupNCCL
-            # watchdog firing and crashing the process.
+            # Synchronize the current accelerator stream so the timeout fires
+            # before the NCCL/XCCL watchdog can crash the process.
             if timeout is not None:
-                torch.cuda.synchronize()
+                torch.accelerator.synchronize()
 
             return True
 
@@ -990,12 +994,11 @@ class ProcessGroupXCCL(ProcessGroupWrapper):
         # stream.
         self._errored = RuntimeError("aborted")
 
-        super().abort(errored)
+        super().abort(errored=errored)
 
     def errored(self) -> Optional[Exception]:
         # force a synchronization to ensure all work is complete
-        torch.xpu.current_stream().synchronize()
-
+        synchronize()
         return self._errored
 
     def getBackendName(self) -> str:
@@ -2104,10 +2107,13 @@ class ProcessGroupBabyXCCL(ProcessGroupBaby):
         # Check if XPU and XCCL are available
         from torch.distributed import ProcessGroupXCCL as BaseProcessGroupXCCL
 
+        # pyre-fixme[16]: no attribute ProcessGroupXCCL
+        opts = BaseProcessGroupXCCL.Options()
+
         pg = BaseProcessGroup(store, rank, world_size)
         pg._set_default_backend(ProcessGroup.BackendType.XCCL)
-        # pyre-fixme[16]: no attribute ProcessGroupNCCL
-        backend_class = BaseProcessGroupXCCL(store, rank, world_size)
+        # pyre-fixme[16]: no attribute ProcessGroupXCCL
+        backend_class = BaseProcessGroupXCCL(store, rank, world_size, opts)
         backend_class._set_sequence_number_for_group()
         pg._register_backend(
             torch.device("xpu"), ProcessGroup.BackendType.XCCL, backend_class

--- a/torchft/quantization.py
+++ b/torchft/quantization.py
@@ -6,7 +6,6 @@
 
 # pyre-unsafe
 import torch
-import torch.cuda as cuda
 
 # pyre-ignore[21]: Could not find a module corresponding to import `triton`
 import triton
@@ -26,16 +25,28 @@ SCALE_TL_DTYPE_BYTES = tl.constexpr(4)
 BLOCK_SIZE_T: int = 2048
 
 
+def _supports_native_fp8() -> bool:
+    """
+    Returns True when the current accelerator supports native FP8.
+
+    On CUDA, this corresponds to compute capability >= (9, 0). On XPU, FP8
+    hardware support is currently absent, so return False explicitly.
+    """
+    if torch.cuda.is_available():
+        return torch.cuda.get_device_capability() >= (9, 0)
+    return False
+
+
 # pyre-ignore[11]: Annotation `tl.constexpr` is not defined
 def _get_fp8_max() -> tl.constexpr:
-    if cuda.get_device_capability() >= (9, 0):
+    if _supports_native_fp8():
         return tl.constexpr(448.0)
     else:
         return tl.constexpr(127)
 
 
 def _get_fp8_type() -> tl.constexpr:
-    if cuda.get_device_capability() >= (9, 0):
+    if _supports_native_fp8():
         return tl.constexpr(tl.float8e4nv)
     else:
         return tl.constexpr(tl.int8)

--- a/train_diloco.py
+++ b/train_diloco.py
@@ -30,6 +30,7 @@ from torchft import (
     ProcessGroupBabyNCCL,
     ProcessGroupGloo,
     ProcessGroupNCCL,
+    ProcessGroupXCCL,
 )
 from torchft.checkpointing.http_transport import HTTPTransport
 from torchft.local_sgd import DiLoCo
@@ -58,14 +59,22 @@ def main() -> None:
             "outer_optim": outer_optimizer.state_dict(),
         }
 
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    pg = (
-        ProcessGroupNCCL(
-            timeout=timedelta(seconds=10),
+    if torch.xpu.is_available():
+        # XPU has no env-var equivalent of CUDA_VISIBLE_DEVICES that PyTorch
+        # honors, so multiple replica groups on the same host would all default
+        # to xpu:0 and collide. Pin each replica to its own device explicitly.
+        torch.xpu.set_device(REPLICA_GROUP_ID % torch.xpu.device_count())
+        device = torch.device("xpu")
+        pg = ProcessGroupXCCL(timeout=timedelta(seconds=10))
+    else:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        pg = (
+            ProcessGroupNCCL(
+                timeout=timedelta(seconds=10),
+            )
+            if torch.cuda.is_available() and USE_NCCL
+            else ProcessGroupGloo(timeout=timedelta(seconds=10))
         )
-        if torch.cuda.is_available() and USE_NCCL
-        else ProcessGroupGloo(timeout=timedelta(seconds=10))
-    )
 
     transport = HTTPTransport(
         timeout=timedelta(seconds=10),


### PR DESCRIPTION
## Summary

Continuation of [PR-260](https://github.com/meta-pytorch/torchft/pull/260) as per [RFC-257](https://github.com/meta-pytorch/torchft/issues/257)

Extends torchft to run on Intel XPU accelerators alongside CUDA, using PyTorch's
device-agnostic accelerator API (`torch.accelerator.*`) so the same code path
covers both backends.

## Validation
Validated on Intel(R) Arc(TM) Pro B60 Graphics

## Test plan
Test script changes will be done as part of [PR-326](https://github.com/meta-pytorch/torchft/pull/326/)

CC: @tushar00jain @d4l3k  @rbabukv