### PR TITLE
Remove unused imports in torchft and fblearner (F401) (#333)

### DIFF
--- a/torchft/collectives_test.py
+++ b/torchft/collectives_test.py
@@ -18,17 +18,15 @@ from torchft.process_group import ProcessGroup
 from torchft.process_group_test import MultiPgBaseTest
 
 try:
-    # pyre-ignore[21]: Could not find a module corresponding to import `triton`
-    import triton
-except ImportError:
-    pass
-else:
     from torchft.collectives import (
         allocate_reduce_scatter_output,
         allreduce_quantized,
         get_padded_sizes,
         reduce_scatter_quantized,
     )
+except ImportError:
+    pass
+else:
 
     def _check_result_tolerance(
         actual: torch.Tensor, expected: torch.Tensor, tolerance: float

--- a/torchft/ddp.py
+++ b/torchft/ddp.py
@@ -12,7 +12,6 @@ This module implements a DistributedDataParallel wrapper that works with the
 Manager to provide fault tolerance.
 """
 
-import os
 import sys
 from typing import cast, Optional, TYPE_CHECKING
 from unittest.mock import patch

--- a/torchft/parameter_server_test.py
+++ b/torchft/parameter_server_test.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from unittest import TestCase
-from unittest.mock import MagicMock
 
 import torch
 from torchft.parameter_server import ParameterServer

--- a/torchft/torchcomms_test.py
+++ b/torchft/torchcomms_test.py
@@ -19,7 +19,6 @@ from torch._C._distributed_c10d import (
     AllreduceOptions,
     AllToAllOptions,
     BarrierOptions,
-    BroadcastOptions,
     ReduceOp,
     ReduceScatterOptions,
 )


### PR DESCRIPTION
Summary:

Squashes auto-generated F401 fixes that remove unused imports into a single diff:
- `torchft/ddp.py`: remove unused `os` import
- `torchft/torchcomms_test.py`: remove unused `BroadcastOptions` import
- `torchft/parameter_server_test.py`: remove unused `MagicMock` import
- `torchft/collectives_test.py`: remove unused `triton` import

Differential Revision: D109713335
