### PR TITLE
fix: avoid unstable duration_constructors so torchft builds on Rust < 1.91

### DIFF
--- a/src/lighthouse.rs
+++ b/src/lighthouse.rs
@@ -695,7 +695,8 @@ mod tests {
         assert!(reason.contains("join timeout"), "{}", reason);
 
         // increase elapsed time to pass join timeout
-        state.participants.get_mut("a").unwrap().joined = now.sub(Duration::from_hours(10));
+        state.participants.get_mut("a").unwrap().joined =
+            now.sub(Duration::from_secs(10 * 60 * 60));
         let (quorum_met, reason) = quorum_compute(now, &state, &opt);
         assert!(quorum_met.is_some(), "{}", reason);
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -31,7 +31,7 @@ pub async fn connect_once(addr: String, connect_timeout: Duration) -> Result<Cha
     let conn = Endpoint::new(addr.clone())?
         .connect_timeout(connect_timeout)
         // Enable HTTP2 keep alives
-        .http2_keep_alive_interval(Duration::from_mins(1))
+        .http2_keep_alive_interval(Duration::from_secs(60)) // 1 minute
         // Time taken for server to respond. 20s is default for GRPC.
         .keep_alive_timeout(Duration::from_secs(20))
         // Enable alive for idle connections.

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -80,8 +80,14 @@ mod tests {
             map
         }
 
-        assert!(try_parse_grpc_timeout(&map("3H")).unwrap() == Some(Duration::from_hours(3)));
-        assert!(try_parse_grpc_timeout(&map("3M")).unwrap() == Some(Duration::from_mins(3)));
+        assert!(
+            try_parse_grpc_timeout(&map("3H")).unwrap()
+                == Some(Duration::from_secs(3 * SECONDS_IN_HOUR))
+        );
+        assert!(
+            try_parse_grpc_timeout(&map("3M")).unwrap()
+                == Some(Duration::from_secs(3 * SECONDS_IN_MINUTE))
+        );
         assert!(try_parse_grpc_timeout(&map("3S")).unwrap() == Some(Duration::from_secs(3)));
         assert!(try_parse_grpc_timeout(&map("3m")).unwrap() == Some(Duration::from_millis(3)));
         assert!(try_parse_grpc_timeout(&map("3u")).unwrap() == Some(Duration::from_micros(3)));


### PR DESCRIPTION
## Summary

`src/net.rs` calls `Duration::from_mins(1)`. `Duration::from_mins`/`from_hours` (the
`duration_constructors` feature, rust-lang/rust#120301) were unstable until Rust 1.91, so building
torchft on older stable Rust fails with:

```
error[E0658]: use of unstable library feature `duration_constructors`
  --> src/net.rs:20:36
```

This was reported on Rust 1.88 (#330). CI did not catch it because every workflow installs
`--default-toolchain=stable`, which is now >= 1.91.

The issue suggests documenting Rust 1.91 as the minimum. This PR instead removes the need for it:
`from_mins(1)` is exactly `from_secs(60)`, so switching to the stable constructor lets torchft build
on the older stable Rust the reporter (and many distro/conda/CI environments) actually have, rather
than forcing everyone onto a bleeding-edge toolchain for a trivial constant.

## Changes

The API was used at four sites (one in production, three in tests), all converted to the identical
`from_secs(...)` value:

- `src/net.rs` — `from_mins(1)` -> `from_secs(60)` (HTTP/2 keep-alive interval)
- `src/timeout.rs` (tests) — `from_hours(3)`/`from_mins(3)` -> `from_secs(3 * SECONDS_IN_HOUR)` /
  `from_secs(3 * SECONDS_IN_MINUTE)`, reusing the module's existing constants so the test mirrors the
  parser it covers
- `src/lighthouse.rs` (test) — `from_hours(10)` -> `from_secs(10 * 60 * 60)`

No behaviour change: each replacement is the same `Duration`.

## Verification

- `rustup toolchain install 1.88.0`
- On `main`: `cargo +1.88.0 check --tests` reproduces `E0658` at all four sites.
- With this change: `cargo +1.88.0 check --tests` compiles clean (build floor dropped to <= 1.88).
- `cargo +nightly fmt --check` clean; `cargo +stable check --tests` green.
- `grep -rn "from_mins\|from_hours\|from_days" --include='*.rs'` returns nothing.

## Follow-up

If you would still like the minimum Rust version documented explicitly, I am happy to add a
`rust-version` field to `Cargo.toml` plus a README note in a follow-up. Removing the unstable API
first means that floor can stay conservative instead of being pinned to 1.91.

Closes #330
