### PR TITLE
Improve connection error messages with full error chain and target address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,8 @@ impl ManagerServer {
                     connect_timeout,
                     quorum_retries,
                 ))
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+                // Use the alternate format to include the full error chain.
+                .map_err(|e| PyRuntimeError::new_err(format!("{:#}", e)))?;
             let handle = runtime.spawn(manager.clone().run());
             Ok(Self {
                 handle,
@@ -168,7 +169,8 @@ impl ManagerClient {
                 .build()?;
             let client = runtime
                 .block_on(manager::manager_client_new(addr, connect_timeout))
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+                // Use the alternate format to include the full error chain.
+                .map_err(|e| PyRuntimeError::new_err(format!("{:#}", e)))?;
 
             Ok(Self { runtime, client })
         })
@@ -502,7 +504,8 @@ impl LighthouseClient {
                 .build()?;
             let client = runtime
                 .block_on(manager::lighthouse_client_new(addr, connect_timeout))
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+                // Use the alternate format to include the full error chain.
+                .map_err(|e| PyRuntimeError::new_err(format!("{:#}", e)))?;
             Ok(Self { client, runtime })
         })
     }

--- a/src/net.rs
+++ b/src/net.rs
@@ -6,6 +6,7 @@
 
 use std::time::Duration;
 
+use anyhow::Context;
 use anyhow::Result;
 use tonic::transport::Channel;
 use tonic::transport::Endpoint;
@@ -13,8 +14,21 @@ use tonic::transport::Endpoint;
 use crate::retry::ExponentialBackoff;
 use crate::retry::retry_backoff;
 
+/// Formats an error with its full source chain since the Display
+/// implementation for many errors (e.g. tonic's "transport error") omits the
+/// underlying cause.
+fn format_error_chain(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut out = err.to_string();
+    let mut source = err.source();
+    while let Some(err) = source {
+        out.push_str(&format!(": {}", err));
+        source = err.source();
+    }
+    out
+}
+
 pub async fn connect_once(addr: String, connect_timeout: Duration) -> Result<Channel> {
-    let conn = Endpoint::new(addr)?
+    let conn = Endpoint::new(addr.clone())?
         .connect_timeout(connect_timeout)
         // Enable HTTP2 keep alives
         .http2_keep_alive_interval(Duration::from_mins(1))
@@ -23,7 +37,9 @@ pub async fn connect_once(addr: String, connect_timeout: Duration) -> Result<Cha
         // Enable alive for idle connections.
         .keep_alive_while_idle(true)
         .connect()
-        .await?;
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", format_error_chain(&e)))
+        .with_context(|| format!("failed to connect to {}", addr))?;
     Ok(conn)
 }
 
@@ -39,4 +55,33 @@ pub async fn connect(addr: String, connect_timeout: Duration) -> Result<Channel>
         || Box::pin(connect_once(addr.clone(), connect_timeout)),
     )
     .await
+    .with_context(|| {
+        format!(
+            "failed to connect to {} within timeout of {:?}; verify the address is correct and the server is running and reachable, or increase connect_timeout",
+            addr, connect_timeout
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_connect_error_message() {
+        let addr = "http://127.0.0.1:1".to_string();
+        let err = connect(addr.clone(), Duration::from_millis(100))
+            .await
+            .expect_err("connect should fail");
+        // Use the alternate format to include the full error chain, matching
+        // how the error is surfaced to Python in lib.rs.
+        let msg = format!("{:#}", err);
+        assert!(msg.contains(&addr), "missing addr in error: {}", msg);
+        assert!(msg.contains("connect_timeout"), "missing hint: {}", msg);
+        assert!(
+            msg.contains("Connection refused"),
+            "missing underlying cause in error: {}",
+            msg
+        );
+    }
 }


### PR DESCRIPTION
## Problem

When `ManagerServer` fails to connect to the lighthouse (or `ManagerClient`/`LighthouseClient` fail to connect to their servers), the Python-side exception is just:

```
RuntimeError: transport error
```

This is because tonic's transport error `Display` omits the underlying source (e.g. "Connection refused"), and `e.to_string()` on an `anyhow::Error` drops the context chain. The result gives no indication of which address failed, why, or how to fix it — see the traceback in torchtitan's torchft trainer where `ManagerServer(...)` fails with only "transport error".

## Changes

- `net.rs`: `connect_once` now flattens the full `std::error::Error` source chain (so the root cause like "Connection refused" is included) and adds the target address as context. `connect` adds the address, the configured `connect_timeout`, and an actionable hint as outer context.
- `lib.rs`: `ManagerServer::new`, `ManagerClient::new`, and `LighthouseClient::new` now format errors with anyhow's alternate `{:#}` format so the whole context chain crosses the PyO3 boundary instead of just the outermost message.
- Added a test asserting the error message contains the address, the underlying cause, and the connect_timeout hint.

The same failure now reports:

```
RuntimeError: failed to connect to http://lighthouse:29510 within timeout of 10s; verify the address is correct and the server is running and reachable, or increase connect_timeout: failed to connect to http://lighthouse:29510: transport error: error trying to connect: tcp connect error: Connection refused (os error 111)
```

## Test plan

`cargo test` passes; new `net::tests::test_connect_error_message` exercises a refused connection and asserts the full chain is surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)