### PR TITLE
Use the current accelerator for streams and process-group lifecycle

### DIFF
--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -331,10 +331,10 @@ class ProcessGroup(BaseProcessGroup):
             return self
 
         devices = ["cpu"]
-        if torch.cuda.is_available():
-            devices.append("cuda")
-        elif torch.xpu.is_available():
-            devices.append("xpu")
+        if torch.accelerator.is_available():
+            accelerator = torch.accelerator.current_accelerator().type
+            if accelerator not in devices:
+                devices.append(accelerator)
         dist.Backend.register_backend(group_name, create_pg, devices=devices)
 
         return group_name
@@ -495,10 +495,10 @@ class ProcessGroupWrapper(ProcessGroup):
             else:
                 backend = None
                 try:
-                    if torch.cuda.is_available():
-                        backend = pg._get_backend(torch.device("cuda"))
-                    elif torch.xpu.is_available():
-                        backend = pg._get_backend(torch.device("xpu"))
+                    if torch.accelerator.is_available():
+                        backend = pg._get_backend(
+                            torch.accelerator.current_accelerator()
+                        )
                 except RuntimeError:
                     backend = None
                 if backend is not None and hasattr(backend, "abort"):

--- a/torchft/process_group_test.py
+++ b/torchft/process_group_test.py
@@ -9,6 +9,7 @@ import os
 import sys
 from concurrent.futures import Future, ProcessPoolExecutor, ThreadPoolExecutor
 from datetime import timedelta
+from types import SimpleNamespace
 from typing import Any, Callable, cast, Dict, List
 from unittest import skipIf, skipUnless, TestCase
 from unittest.mock import Mock, patch
@@ -495,6 +496,88 @@ _ALL_COLLECTIVES: List[str] = list(_COLLECTIVE_TO_FUNC.keys())
 
 
 class ProcessGroupTest(TestCase):
+    @patch("torchft.process_group.dist.Backend.register_backend")
+    @patch("torchft.process_group.torch.accelerator.current_accelerator")
+    @patch("torchft.process_group.torch.accelerator.is_available", return_value=True)
+    def test_register_includes_current_accelerator(
+        self,
+        _is_available: Mock,
+        current_accelerator: Mock,
+        register_backend: Mock,
+    ) -> None:
+        current_accelerator.return_value = SimpleNamespace(type="test_accel")
+
+        group_name = ProcessGroupDummy(0, 1)._register("test_backend")
+
+        self.assertEqual(group_name, "torchft-dummy:test_backend")
+        self.assertEqual(
+            register_backend.call_args.kwargs["devices"], ["cpu", "test_accel"]
+        )
+
+    @patch("torchft.process_group.dist.Backend.register_backend")
+    @patch("torchft.process_group.torch.accelerator.current_accelerator")
+    @patch("torchft.process_group.torch.accelerator.is_available", return_value=True)
+    def test_register_does_not_duplicate_cpu(
+        self,
+        _is_available: Mock,
+        current_accelerator: Mock,
+        register_backend: Mock,
+    ) -> None:
+        current_accelerator.return_value = SimpleNamespace(type="cpu")
+
+        ProcessGroupDummy(0, 1)._register("test_cpu_backend")
+
+        self.assertEqual(register_backend.call_args.kwargs["devices"], ["cpu"])
+
+    @patch("torchft.process_group.dist.Backend.register_backend")
+    @patch("torchft.process_group.torch.accelerator.is_available", return_value=False)
+    def test_register_without_accelerator_uses_cpu_only(
+        self, _is_available: Mock, register_backend: Mock
+    ) -> None:
+        ProcessGroupDummy(0, 1)._register("test_no_accelerator")
+
+        self.assertEqual(register_backend.call_args.kwargs["devices"], ["cpu"])
+
+    @patch("torchft.process_group.torch.accelerator.current_accelerator")
+    @patch("torchft.process_group.torch.accelerator.is_available", return_value=True)
+    def test_wrapper_abort_uses_current_accelerator_backend(
+        self, _is_available: Mock, current_accelerator: Mock
+    ) -> None:
+        device = torch.device("privateuseone")
+        current_accelerator.return_value = device
+        backend = Mock()
+
+        class BackendOnlyProcessGroup:
+            def _get_backend(self, requested_device: torch.device) -> Mock:
+                self.requested_device = requested_device
+                return backend
+
+        pg = BackendOnlyProcessGroup()
+        wrapper = ProcessGroupWrapper(pg=cast(Any, pg))
+
+        wrapper.abort()
+
+        self.assertEqual(pg.requested_device, device)
+        backend.abort.assert_called_once_with()
+        self.assertIsNone(wrapper._pg)
+
+    @patch("torchft.process_group.torch.accelerator.current_accelerator")
+    @patch("torchft.process_group.torch.accelerator.is_available", return_value=True)
+    def test_wrapper_abort_backend_lookup_failure_is_nonfatal(
+        self, _is_available: Mock, current_accelerator: Mock
+    ) -> None:
+        current_accelerator.return_value = torch.device("privateuseone")
+
+        class FailingBackendLookupProcessGroup:
+            def _get_backend(self, _device: torch.device) -> None:
+                raise RuntimeError("backend unavailable")
+
+        wrapper = ProcessGroupWrapper(pg=cast(Any, FailingBackendLookupProcessGroup()))
+
+        wrapper.abort()
+
+        self.assertIsNone(wrapper._pg)
+
     @parameterized.expand(["cpu", "cuda"])
     def test_gloo_apis(self, device: str) -> None:
         if device == "cuda" and not torch.cuda.is_available():

--- a/torchft/utils.py
+++ b/torchft/utils.py
@@ -9,19 +9,19 @@ Utility functions for TorchFT.
 """
 
 from contextlib import nullcontext
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import torch
 
 
 def get_stream_context(
     stream: Optional[torch.Stream],
-) -> Union[torch.cuda.StreamContext, torch.xpu.StreamContext, nullcontext[None]]:
+) -> Any:
     """
     Get the appropriate stream context for the given stream.
 
-    This function provides a unified way to handle stream contexts across different
-    accelerator types (CUDA, XPU).
+    This function provides a unified way to handle stream contexts across
+    accelerator types.
 
     Args:
         stream: The stream to create a context for. If None, returns nullcontext.
@@ -30,38 +30,41 @@ def get_stream_context(
         The appropriate stream context for the accelerator type, or nullcontext
         if stream is None or no accelerator is available.
     """
-    if stream is not None:
-        if torch.cuda.is_available():
-            # pyre-fixme[6]: Expected `Optional[streams.Stream]` but got `_C.Stream`
-            return torch.cuda.stream(stream)
-        elif torch.xpu.is_available():
-            # pyre-fixme[6]: Expected `Optional[streams.Stream]` but got `_C.Stream`
-            return torch.xpu.stream(stream)
-        else:
-            return nullcontext()
-    else:
+    if stream is None or not torch.accelerator.is_available():
         return nullcontext()
+
+    accelerator = torch.accelerator.current_accelerator().type
+    accelerator_module = getattr(torch, accelerator, None)
+    if accelerator_module is None or not hasattr(accelerator_module, "stream"):
+        return nullcontext()
+    return accelerator_module.stream(stream)
 
 
 def record_event() -> None:
     """
     Record an event in the current stream.
 
-    This function provides a unified way to record events across different
-    accelerator types (CUDA, XPU).
+    This function provides a unified way to record events across accelerator
+    types.
     """
-    if torch.xpu.is_available():
-        torch.xpu.current_stream().record_event(torch.xpu.Event())
-    else:
-        torch.cuda.current_stream().record_event(torch.cuda.Event(interprocess=True))
+    if not torch.accelerator.is_available():
+        return
+
+    accelerator = torch.accelerator.current_accelerator().type
+    accelerator_module = getattr(torch, accelerator)
+    event = (
+        accelerator_module.Event(interprocess=True)
+        if accelerator == "cuda"
+        else accelerator_module.Event()
+    )
+    accelerator_module.current_stream().record_event(event)
 
 
 def synchronize() -> None:
     """
-    This function provides a unified way to synchronize current stream across different
-    accelerator types (CUDA, XPU).
+    This function provides a unified way to synchronize the current stream
+    across accelerator types.
     """
-    if torch.cuda.is_available():
-        torch.cuda.current_stream().synchronize()
-    elif torch.xpu.is_available():
-        torch.xpu.current_stream().synchronize()
+    if torch.accelerator.is_available():
+        accelerator = torch.accelerator.current_accelerator().type
+        getattr(torch, accelerator).current_stream().synchronize()

--- a/torchft/utils_test.py
+++ b/torchft/utils_test.py
@@ -1,0 +1,84 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from torchft.utils import get_stream_context, record_event, synchronize
+
+
+class UtilsTest(TestCase):
+    @patch("torchft.utils.torch.accelerator.is_available", return_value=False)
+    def test_stream_context_without_accelerator_returns_nullcontext(
+        self, _is_available: MagicMock
+    ) -> None:
+        self.assertIsInstance(get_stream_context(MagicMock()), nullcontext)
+
+    @patch("torchft.utils.torch.accelerator.current_accelerator")
+    @patch("torchft.utils.torch.accelerator.is_available", return_value=True)
+    def test_stream_context_uses_current_accelerator_module(
+        self, _is_available: MagicMock, current_accelerator: MagicMock
+    ) -> None:
+        current_accelerator.return_value = SimpleNamespace(type="test_accel")
+        stream = MagicMock()
+        context = MagicMock()
+        accelerator_module = MagicMock()
+        accelerator_module.stream.return_value = context
+
+        with patch.object(torch, "test_accel", accelerator_module, create=True):
+            self.assertIs(get_stream_context(stream), context)
+
+        accelerator_module.stream.assert_called_once_with(stream)
+
+    @patch("torchft.utils.torch.accelerator.current_accelerator")
+    @patch("torchft.utils.torch.accelerator.is_available", return_value=True)
+    def test_record_event_uses_current_accelerator_module(
+        self, _is_available: MagicMock, current_accelerator: MagicMock
+    ) -> None:
+        current_accelerator.return_value = SimpleNamespace(type="test_accel")
+        accelerator_module = MagicMock()
+        event = accelerator_module.Event.return_value
+
+        with patch.object(torch, "test_accel", accelerator_module, create=True):
+            record_event()
+
+        accelerator_module.Event.assert_called_once_with()
+        accelerator_module.current_stream.return_value.record_event.assert_called_once_with(
+            event
+        )
+
+    @patch("torchft.utils.torch.accelerator.current_accelerator")
+    @patch("torchft.utils.torch.accelerator.is_available", return_value=True)
+    def test_record_event_keeps_cuda_interprocess_event(
+        self, _is_available: MagicMock, current_accelerator: MagicMock
+    ) -> None:
+        current_accelerator.return_value = SimpleNamespace(type="cuda")
+
+        with patch.object(torch.cuda, "Event") as event_cls:
+            with patch.object(torch.cuda, "current_stream") as current_stream:
+                record_event()
+
+        event_cls.assert_called_once_with(interprocess=True)
+        current_stream.return_value.record_event.assert_called_once_with(
+            event_cls.return_value
+        )
+
+    @patch("torchft.utils.torch.accelerator.current_accelerator")
+    @patch("torchft.utils.torch.accelerator.is_available", return_value=True)
+    def test_synchronize_uses_current_accelerator_stream(
+        self, _is_available: MagicMock, current_accelerator: MagicMock
+    ) -> None:
+        current_accelerator.return_value = SimpleNamespace(type="test_accel")
+        accelerator_module = MagicMock()
+
+        with patch.object(torch, "test_accel", accelerator_module, create=True):
+            synchronize()
+
+        accelerator_module.current_stream.return_value.synchronize.assert_called_once_with()


### PR DESCRIPTION
## Summary

- make TorchFT stream, event, and synchronization helpers use the current PyTorch accelerator
- use the current accelerator when registering reconfigurable process groups and resolving an abort-capable backend
- preserve CPU/Gloo and existing CUDA/XPU behavior without adding a backend-specific dependency

Closes #340

## Testing

```text
python -m pytest -q \
  torchft/utils_test.py \
  torchft/process_group_test.py \
  -k "stream_context_without_accelerator_returns_nullcontext or \
      stream_context_uses_current_accelerator_module or \
      record_event_uses_current_accelerator_module or \
      record_event_keeps_cuda_interprocess_event or \
      synchronize_uses_current_accelerator_stream or \
      register_includes_current_accelerator or \
      register_does_not_duplicate_cpu or \
      register_without_accelerator_uses_cpu_only or \
      wrapper_abort_uses_current_accelerator_backend or \
      wrapper_abort_backend_lookup_failure_is_nonfatal"
10 passed
```
