### PR TITLE
Add optional CPU staging for LocalSGD averaging

### DIFF
--- a/docs/source/local_sgd.rst
+++ b/docs/source/local_sgd.rst
@@ -2,3 +2,37 @@
     :members:
     :undoc-members:
     :show-inheritance:
+
+CPU staging for averaged parameters
+-----------------------------------
+
+``LocalSGD`` can stage averaged parameters on CPU while waiting for the quorum
+to commit. Enable this path when synchronization-time accelerator memory is the
+limiting factor:
+
+.. code-block:: python
+
+    with LocalSGD(
+        manager=manager,
+        model=model,
+        optimizer=optimizer,
+        sync_every=8,
+        offload_averaged_parameters_to_cpu=True,
+    ):
+        train(model, optimizer)
+
+The option is disabled by default, so existing callers retain the original
+behavior. When enabled, LocalSGD all-reduces one parameter at a time and moves
+each averaged result to CPU before processing the next parameter. If the quorum
+commits, the staged values are copied back to the original parameter devices;
+otherwise, they are discarded.
+
+This reduces peak accelerator memory used by averaged parameter copies, but it
+has the following trade-offs:
+
+* CPU memory must hold the averaged parameters until the quorum commits.
+* Device-to-host and host-to-device transfers add synchronization overhead.
+* Waiting for each parameter all-reduce serializes the synchronization path and
+  may reduce throughput.
+* Only averaged model parameters are staged. Model weights, gradients, and
+  optimizer state are not offloaded.

--- a/torchft/local_sgd.py
+++ b/torchft/local_sgd.py
@@ -42,6 +42,31 @@ def extract_local_tensor(t: torch.Tensor) -> torch.Tensor:
     return new_tensor
 
 
+def _copy_local_tensor_to_parameter(
+    parameter: torch.Tensor, local_tensor: torch.Tensor
+) -> None:
+    target_device = (
+        parameter.to_local().device
+        if isinstance(parameter, DTensor)
+        else parameter.device
+    )
+    if local_tensor.device != target_device:
+        local_tensor = local_tensor.to(device=target_device, non_blocking=False)
+
+    if isinstance(parameter, DTensor):
+        parameter.data.copy_(
+            DTensor.from_local(
+                local_tensor,
+                parameter.device_mesh,
+                parameter.placements,
+                shape=parameter.shape,
+                stride=parameter.stride(),
+            )
+        )
+    else:
+        parameter.data.copy_(local_tensor)
+
+
 class LocalSGD:
     """
     LocalSGD is a context manager that
@@ -66,6 +91,7 @@ class LocalSGD:
         model: nn.Module,
         optimizer: optim.Optimizer,
         sync_every: int,
+        offload_averaged_parameters_to_cpu: bool = False,
     ) -> None:
         """
         Args:
@@ -73,6 +99,9 @@ class LocalSGD:
             model: The model to wrap.
             optimizer: The optimizer used by the model.
             sync_every: How often to sync the model weights.
+            offload_averaged_parameters_to_cpu: Stage each averaged parameter
+                on CPU until the quorum commits. This reduces peak accelerator
+                memory during synchronization at the cost of host transfers.
         """
         super().__init__()
         self._manager = manager
@@ -80,6 +109,9 @@ class LocalSGD:
         self._local_optimizer = optimizer
         self._local_step = 0
         self._sync_every = sync_every
+        self._offload_averaged_parameters_to_cpu = (
+            offload_averaged_parameters_to_cpu
+        )
         assert sync_every >= 1, "sync_every must be greater than or equal to 1"
 
         self._hooks: List[RemovableHandle] = []
@@ -138,6 +170,22 @@ class LocalSGD:
         """
         Performs the synchronization of the model weights across the manager.
         """
+        if self._offload_averaged_parameters_to_cpu:
+            averaged_parameters = []
+            parameters = list(self._model.parameters())
+            for parameter in parameters:
+                averaged_parameter = extract_local_tensor(parameter)
+                self._manager.allreduce(averaged_parameter).wait()
+                averaged_parameters.append(averaged_parameter.detach().cpu())
+                del averaged_parameter
+
+            if self._manager.should_commit():
+                for parameter, averaged_parameter in zip(
+                    parameters, averaged_parameters
+                ):
+                    _copy_local_tensor_to_parameter(parameter, averaged_parameter)
+            return
+
         averaged_parameters = self._average()
         if self._manager.should_commit():
             # Update the model parameters with the averaged values

--- a/torchft/local_sgd_test.py
+++ b/torchft/local_sgd_test.py
@@ -6,14 +6,19 @@
 
 from typing import Dict
 from unittest import TestCase
-from unittest.mock import create_autospec, MagicMock
+from unittest.mock import create_autospec, MagicMock, patch
 
 import torch
 from parameterized import parameterized
 from torch import nn, optim, Tensor
 from torch.distributed.distributed_c10d import Work
 from torch.distributed.tensor import DTensor
-from torchft.local_sgd import DiLoCo, extract_local_tensor, LocalSGD
+from torchft.local_sgd import (
+    _copy_local_tensor_to_parameter,
+    DiLoCo,
+    extract_local_tensor,
+    LocalSGD,
+)
 from torchft.manager import Manager
 from torchft.work import _DummyWork
 
@@ -69,6 +74,84 @@ class TinyModel(nn.Module):
 
 
 class LocalSGDTest(TestCase):
+    def test_cpu_offload_commits_averaged_parameters(self) -> None:
+        model = TinyModel()
+        optimizer = optim.SGD(model.parameters())
+        manager = create_manager()
+        manager.should_commit.return_value = True
+        expected = [parameter.detach().clone() + 10 for parameter in model.parameters()]
+
+        def average(tensor: torch.Tensor) -> Work:
+            tensor.add_(10)
+            return _DummyWork(tensor)
+
+        manager.allreduce.side_effect = average
+        local_sgd = LocalSGD(
+            manager,
+            model,
+            optimizer,
+            sync_every=1,
+            offload_averaged_parameters_to_cpu=True,
+        )
+
+        local_sgd._perform_sync()
+
+        for parameter, expected_parameter in zip(model.parameters(), expected):
+            torch.testing.assert_close(parameter, expected_parameter)
+        self.assertEqual(manager.allreduce.call_count, 2)
+        manager.should_commit.assert_called_once_with()
+
+    def test_cpu_offload_discards_uncommitted_parameters(self) -> None:
+        model = TinyModel()
+        optimizer = optim.SGD(model.parameters())
+        manager = create_manager()
+        manager.should_commit.return_value = False
+        expected = [parameter.detach().clone() for parameter in model.parameters()]
+
+        def average(tensor: torch.Tensor) -> Work:
+            tensor.add_(10)
+            return _DummyWork(tensor)
+
+        manager.allreduce.side_effect = average
+        local_sgd = LocalSGD(
+            manager,
+            model,
+            optimizer,
+            sync_every=1,
+            offload_averaged_parameters_to_cpu=True,
+        )
+
+        local_sgd._perform_sync()
+
+        for parameter, expected_parameter in zip(model.parameters(), expected):
+            torch.testing.assert_close(parameter, expected_parameter)
+        self.assertEqual(manager.allreduce.call_count, 2)
+        manager.should_commit.assert_called_once_with()
+
+    @patch("torchft.local_sgd.DTensor.from_local")
+    def test_copy_local_tensor_reconstructs_dtensor(
+        self, from_local: MagicMock
+    ) -> None:
+        parameter = MagicMock(spec=DTensor)
+        parameter.to_local.return_value.device = torch.device("cpu")
+        parameter.device_mesh = MagicMock()
+        parameter.placements = (MagicMock(),)
+        parameter.shape = torch.Size([2])
+        parameter.stride.return_value = (1,)
+        local_tensor = torch.tensor([4.0, 5.0])
+        reconstructed = from_local.return_value
+
+        _copy_local_tensor_to_parameter(parameter, local_tensor)
+
+        from_local.assert_called_once_with(
+            local_tensor,
+            parameter.device_mesh,
+            parameter.placements,
+            shape=parameter.shape,
+            stride=(1,),
+        )
+        parameter.data.copy_.assert_called_once_with(reconstructed)
+
     def test_local_sgd_healthy(self) -> None:
         model = SimpleModel()
         optimizer = optim.SGD(model.parameters())


### PR DESCRIPTION
## Summary

- add an opt-in LocalSGD policy that stages averaged parameters on CPU
- preserve accelerator-resident averaging by default
- document the memory, host-memory, and transfer tradeoffs

Closes #342

## Testing

```text
python -m pytest -q torchft/local_sgd_test.py
11 passed
```

