### PR TITLE
Make FSDP quorum recovery state-safe

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -535,6 +535,14 @@ fn compute_quorum_results(
     // Compute recovery assignments
 
     let force_recover = init_sync && max_step == 0;
+    // FSDP checkpoint callbacks can contain replica-local collectives. Keep
+    // every worker in a replica on the same recovery side instead of rotating
+    // the initial source by group rank.
+    let recovery_primary = if force_recover {
+        max_participants[0]
+    } else {
+        primary
+    };
 
     // Nodes are recovering if
     // 1. not at the max step (init_sync)
@@ -543,7 +551,7 @@ fn compute_quorum_results(
         .iter()
         .enumerate()
         .filter_map(|(i, p)| {
-            if p.step != max_step || force_recover && primary.replica_id != p.replica_id {
+            if p.step != max_step || force_recover && recovery_primary.replica_id != p.replica_id {
                 Some(i)
             } else {
                 None
@@ -570,7 +578,10 @@ fn compute_quorum_results(
     // The rank of the node that this rank is recovering from.
     let mut recover_src_replica_rank: Option<i64> = None;
     for (i, recovering_rank) in all_recover_dst_replica_ranks.iter().enumerate() {
-        let up_to_date_idx = (i + group_rank as usize) % up_to_date_ranks.len();
+        // Assign all workers of a recovering replica to the same source
+        // replica. Different recovering replicas are still spread across the
+        // available up-to-date replicas.
+        let up_to_date_idx = i % up_to_date_ranks.len();
         let recovering_recover_src_replica_rank = up_to_date_ranks[up_to_date_idx];
         if !recovery_assignments.contains_key(&recovering_recover_src_replica_rank) {
             recovery_assignments.insert(recovering_recover_src_replica_rank, Vec::new());
@@ -921,13 +932,18 @@ mod tests {
         assert_eq!(results.recover_src_replica_rank, Some(0));
         assert_eq!(results.recover_dst_replica_ranks, Vec::<i64>::new());
 
-        // rank 1 assignments should be offset from rank 0 above and the primary
+        // Every worker in a replica must use the same recovery source.
 
         let results = compute_quorum_results("replica_1", 1, &quorum, true)?;
-        assert!(!results.heal);
+        assert!(results.heal);
         assert_eq!(results.replica_rank, 1);
+        assert_eq!(results.recover_src_replica_rank, Some(0));
+        assert_eq!(results.recover_dst_replica_ranks, Vec::<i64>::new());
+
+        let results = compute_quorum_results("replica_0", 1, &quorum, true)?;
+        assert!(!results.heal);
         assert_eq!(results.recover_src_replica_rank, None);
-        assert_eq!(results.recover_dst_replica_ranks, vec![0]);
+        assert_eq!(results.recover_dst_replica_ranks, vec![1]);
 
         Ok(())
     }
@@ -1013,13 +1029,13 @@ mod tests {
         assert_eq!(results.recover_src_replica_rank, None);
         assert_eq!(results.recover_dst_replica_ranks, vec![2]);
 
-        // rank 1 assignments should be offset from rank 0 above
+        // rank 1 assignments must match rank 0 for collective state_dicts.
 
         let results = compute_quorum_results("replica_1", 1, &quorum, true)?;
         assert!(!results.heal);
         assert_eq!(results.replica_rank, 1);
         assert_eq!(results.recover_src_replica_rank, None);
-        assert_eq!(results.recover_dst_replica_ranks, vec![2]);
+        assert_eq!(results.recover_dst_replica_ranks, vec![0, 4]);
 
         Ok(())
     }

--- a/torchft/checkpointing/http_transport.py
+++ b/torchft/checkpointing/http_transport.py
@@ -266,10 +266,15 @@ class HTTPTransport(CheckpointTransport[T]):
 
 
 def _to_cpu(values: List[T], pin_memory: bool) -> List[T]:
+    accelerator_type = (
+        torch.accelerator.current_accelerator().type
+        if torch.accelerator.is_available()
+        else None
+    )
     out = []
     for v in values:
         if isinstance(v, torch.Tensor):
-            if v.device.type in ("cuda", "xpu"):
+            if v.device.type == accelerator_type:
                 if pin_memory:
                     cpu = torch.empty(*tuple(v.size()), dtype=v.dtype, pin_memory=True)
                     cpu.copy_(v, non_blocking=True)

--- a/torchft/checkpointing/http_transport_test.py
+++ b/torchft/checkpointing/http_transport_test.py
@@ -6,13 +6,14 @@
 
 import urllib.error
 from datetime import timedelta
+from types import SimpleNamespace
 from typing import Dict
 from unittest import skipUnless, TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torch
 from parameterized import parameterized
-from torchft.checkpointing.http_transport import HTTPTransport
+from torchft.checkpointing.http_transport import _to_cpu, HTTPTransport
 from torchft.checkpointing.http_transport_bench import main as bench_main
 from torchft.checkpointing.transport import CheckpointTransport
 from torchft.checkpointing.transport_test import (
@@ -22,6 +23,28 @@ from torchft.checkpointing.transport_test import (
 
 
 class TestHTTPTransport(TestCase):
+    @patch(
+        "torchft.checkpointing.http_transport.torch.accelerator.current_accelerator"
+    )
+    @patch(
+        "torchft.checkpointing.http_transport.torch.accelerator.is_available",
+        return_value=True,
+    )
+    def test_to_cpu_uses_current_accelerator(
+        self, _is_available: MagicMock, current_accelerator: MagicMock
+    ) -> None:
+        current_accelerator.return_value = SimpleNamespace(type="test_accel")
+        accelerator_tensor = MagicMock(spec=torch.Tensor)
+        accelerator_tensor.device.type = "test_accel"
+        cpu_tensor = accelerator_tensor.cpu.return_value
+        existing_cpu_tensor = torch.tensor([1.0])
+
+        result = _to_cpu([accelerator_tensor, existing_cpu_tensor], pin_memory=False)
+
+        self.assertIs(result[0], cpu_tensor)
+        self.assertIs(result[1], existing_cpu_tensor)
+        accelerator_tensor.cpu.assert_called_once_with()
+
     @parameterized.expand(
         [
             ("no chunks", 0),

--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -233,6 +233,8 @@ class Manager:
 
         self._load_state_dict_fns: Dict[str, Callable[[object], None]] = {}
         self._user_state_dicts: Dict[str, Callable[[], object]] = {}
+        self._state_dicts_on_training_thread: set[str] = set()
+        self._staged_user_state_dict: Optional[Dict[str, object]] = None
 
         self._original_fr_dump_temp_file: Optional[str] = os.environ.get(
             TORCH_FR_DUMP_TEMP_FILE_ENV
@@ -368,6 +370,9 @@ class Manager:
         if self._is_state_dict_read_allowed:
             return
 
+        if torch.accelerator.is_available():
+            synchronize()
+
         self._is_state_dict_read_allowed = True
         self._state_dict_lock.w_release()
 
@@ -378,18 +383,31 @@ class Manager:
         self._is_state_dict_read_allowed = False
         self._state_dict_lock.w_acquire()
 
+    def _barrier_replica_ranks(self) -> None:
+        if self._group_world_size > 1 and dist.is_initialized():
+            dist.barrier()
+
     def register_state_dict_fn(
         self,
         key: str,
         load_state_dict: Callable[[T], None],
         state_dict: Callable[[], T],
+        state_dict_on_training_thread: bool = False,
     ) -> None:
+        """Register state callbacks used for peer recovery.
+
+        Set ``state_dict_on_training_thread`` when materializing the state can
+        run collectives that require every replica-local rank to enter from the
+        training thread, as with FSDP state dictionaries.
+        """
         # Can't register duplicate keys
         assert key not in self._load_state_dict_fns
         assert key not in self._user_state_dicts
 
         self._load_state_dict_fns[key] = cast(Callable[[object], None], load_state_dict)
         self._user_state_dicts[key] = state_dict
+        if state_dict_on_training_thread:
+            self._state_dicts_on_training_thread.add(key)
 
     def set_state_dict_fns(
         self, load_state_dict: Callable[[T], None], state_dict: Callable[[], T]
@@ -586,8 +604,24 @@ class Manager:
         if self._quorum_future is not None:
             self._quorum_future.result()
 
+        # Selected state_dict callbacks may contain FSDP collectives. Run only
+        # those callbacks on the training thread, where every replica-local
+        # rank enters together. Other callbacks retain the existing lazy path.
+        staged_user_state_dict = {
+            key: value()
+            for key, value in self._user_state_dicts.items()
+            if key in self._state_dicts_on_training_thread
+        }
+        self._staged_user_state_dict = staged_user_state_dict or None
+
         self._errored = None
         self._healing = False
+
+        # The first quorum must finish initialization and apply any recovered
+        # state before the first forward, even when later quorums run async.
+        wait_for_quorum = not self._use_async_quorum or (
+            self._init_sync and self._quorum_id == -1
+        )
 
         # TODO: we should really be wrapping this whole section in a try-except
         # block to allow gracefully recovering from issues in PG setup and quorum.
@@ -603,7 +637,7 @@ class Manager:
                 else -1
             ),
         )
-        if not self._use_async_quorum:
+        if wait_for_quorum:
             self.wait_quorum()
 
             if self._healing:
@@ -661,6 +695,7 @@ class Manager:
         max_replica_world_size = quorum.max_world_size
         heal = quorum.heal
         replica_ids = quorum.replica_ids
+        is_initial_quorum = self._quorum_id == -1
 
         ranks_in_quorum = [
             extract_trailing_digits(replica_id.split(":")[0]) * self._group_world_size
@@ -742,6 +777,12 @@ class Manager:
                 self._logger.exception(f"got exception in pg configure: {e}")
                 self.report_error(e)
                 return
+
+        # FSDP state_dict materialization is collective over the replica-local
+        # default group. Ensure every local rank has finished first-quorum
+        # process-group setup before any rank starts checkpoint recovery.
+        if is_initial_quorum and self._init_sync:
+            self._barrier_replica_ranks()
 
         if allow_heal:
             # run recovery on the recovery stream if available
@@ -955,14 +996,31 @@ class Manager:
         self._batches_committed = state_dict["batches_committed"]
 
     def _manager_state_dict(self) -> Dict[str, object]:
-        with self._state_dict_lock.r_lock():
-            assert len(self._user_state_dicts) > 0, (
-                "user state_dict is not initialized."
-            )
-            return {
-                "user": {key: value() for key, value in self._user_state_dicts.items()},
-                "torchft": self.state_dict(),
-            }
+        # start_quorum() materializes FSDP state dicts on the training thread.
+        # Reading that staged object does not re-enter FSDP collectives, and must
+        # remain possible while the current training step holds the writer lock:
+        # runtime healing waits for this snapshot before optimizer.step() can
+        # release the lock.
+        user_state_dict = dict(self._staged_user_state_dict or {})
+        lazy_state_dicts = {
+            key: value
+            for key, value in self._user_state_dicts.items()
+            if key not in self._state_dicts_on_training_thread
+        }
+
+        # Retain the lock for callbacks that use the existing lazy path. Staged
+        # callbacks are already materialized and do not re-enter collectives.
+        if lazy_state_dicts:
+            with self._state_dict_lock.r_lock():
+                user_state_dict.update(
+                    {key: value() for key, value in lazy_state_dicts.items()}
+                )
+
+        assert user_state_dict, "user state_dict is not initialized."
+        return {
+            "user": user_state_dict,
+            "torchft": self.state_dict(),
+        }
 
     def state_dict(self) -> Dict[str, int]:
         """

--- a/torchft/manager_test.py
+++ b/torchft/manager_test.py
@@ -233,7 +233,11 @@ class TestManager(TestCase):
     def test_quorum_heal_async_not_enough_participants(
         self, client_mock: MagicMock
     ) -> None:
-        manager = self._create_manager(use_async_quorum=True, min_replica_size=2)
+        manager = self._create_manager(
+            use_async_quorum=True,
+            min_replica_size=2,
+            init_sync=False,
+        )
         client_mock().should_commit = mock_should_commit
 
         quorum = QuorumResult()
@@ -295,7 +299,11 @@ class TestManager(TestCase):
 
     @patch("torchft.manager.ManagerClient", autospec=True)
     def test_quorum_heal_async_zero_grad(self, client_mock: MagicMock) -> None:
-        manager = self._create_manager(use_async_quorum=True, min_replica_size=1)
+        manager = self._create_manager(
+            use_async_quorum=True,
+            min_replica_size=1,
+            init_sync=False,
+        )
         client_mock().should_commit = mock_should_commit
 
         quorum = QuorumResult()
@@ -652,6 +660,34 @@ class TestManager(TestCase):
             timedelta(seconds=23),
         )
 
+    @patch("torchft.manager.dist.barrier", autospec=True)
+    @patch("torchft.manager.dist.is_initialized", return_value=True)
+    @patch("torchft.manager.ManagerClient", autospec=True)
+    def test_first_init_quorum_barriers_replica_ranks(
+        self,
+        client_mock: MagicMock,
+        _is_initialized_mock: MagicMock,
+        barrier_mock: MagicMock,
+    ) -> None:
+        manager = self._create_manager(use_async_quorum=False, init_sync=True)
+
+        quorum = QuorumResult()
+        quorum.quorum_id = 123
+        quorum.replica_rank = 1
+        quorum.replica_world_size = 2
+        quorum.recover_src_manager_address = "manager address"
+        quorum.store_address = f"localhost:{self.store.port}"
+        quorum.max_step = 1
+        quorum.max_replica_rank = 1
+        quorum.max_world_size = 2
+        quorum.heal = False
+        client_mock()._quorum.return_value = quorum
+
+        manager.start_quorum()
+        manager.start_quorum()
+
+        barrier_mock.assert_called_once_with()
+
     @patch("torchft.manager.ManagerClient", autospec=True)
     def test_quorum_skip_init(self, client_mock: MagicMock) -> None:
         manager = self._create_manager(
@@ -680,6 +716,107 @@ class TestManager(TestCase):
         manager._init_sync = True
         manager.start_quorum()
         self.assertEqual(client_mock()._quorum.call_args.kwargs["init_sync"], True)
+
+    @patch("torchft.manager.ManagerClient", autospec=True)
+    def test_first_init_quorum_waits_when_async(
+        self, client_mock: MagicMock
+    ) -> None:
+        manager = self._create_manager(use_async_quorum=True, init_sync=True)
+        quorum_future = MagicMock()
+        quorum_future.result.side_effect = lambda: setattr(manager, "_healing", True)
+        manager._apply_pending_state_dict = MagicMock()
+
+        with patch.object(manager._executor, "submit", return_value=quorum_future):
+            manager.start_quorum()
+
+        quorum_future.result.assert_called_once_with()
+        manager._apply_pending_state_dict.assert_called_once_with()
+        self.assertFalse(manager._healing)
+
+    @patch("torchft.manager.ManagerClient", autospec=True)
+    def test_async_quorum_does_not_wait_after_initialization(
+        self, client_mock: MagicMock
+    ) -> None:
+        manager = self._create_manager(use_async_quorum=True, init_sync=True)
+        manager._quorum_id = 123
+        quorum_future = MagicMock()
+
+        with patch.object(manager._executor, "submit", return_value=quorum_future):
+            manager.start_quorum()
+
+        quorum_future.result.assert_not_called()
+
+    @patch("torchft.manager.ManagerClient", autospec=True)
+    def test_first_quorum_does_not_wait_when_init_sync_is_disabled(
+        self, client_mock: MagicMock
+    ) -> None:
+        manager = self._create_manager(use_async_quorum=True, init_sync=False)
+        quorum_future = MagicMock()
+
+        with patch.object(manager._executor, "submit", return_value=quorum_future):
+            manager.start_quorum()
+
+        quorum_future.result.assert_not_called()
+
+    @patch("torchft.manager.ManagerClient", autospec=True)
+    def test_start_quorum_stages_user_state_on_calling_thread(
+        self, client_mock: MagicMock
+    ) -> None:
+        manager = self._create_manager(use_async_quorum=True, init_sync=False)
+        manager._load_state_dict_fns.clear()
+        manager._user_state_dicts.clear()
+        state_dict = MagicMock(return_value={"value": 1})
+        manager.register_state_dict_fn(
+            "default",
+            MagicMock(),
+            state_dict,
+            state_dict_on_training_thread=True,
+        )
+        quorum_future = MagicMock()
+
+        with patch.object(manager._executor, "submit", return_value=quorum_future):
+            manager.start_quorum()
+
+        state_dict.assert_called_once_with()
+        state_dict.reset_mock()
+        result = manager._manager_state_dict()
+        state_dict.assert_not_called()
+        self.assertEqual(result["user"], {"default": {"value": 1}})
+
+    @patch("torchft.manager.ManagerClient", autospec=True)
+    def test_start_quorum_keeps_default_state_dict_lazy(
+        self, client_mock: MagicMock
+    ) -> None:
+        manager = self._create_manager(use_async_quorum=True, init_sync=False)
+        state_dict = MagicMock(return_value={"value": 1})
+        manager._user_state_dicts["default"] = state_dict
+        quorum_future = MagicMock()
+
+        with patch.object(manager._executor, "submit", return_value=quorum_future):
+            manager.start_quorum()
+
+        state_dict.assert_not_called()
+        self.assertIsNone(manager._staged_user_state_dict)
+
+        result = manager._manager_state_dict()
+
+        state_dict.assert_called_once_with()
+        self.assertEqual(result["user"], {"default": {"value": 1}})
+
+    @patch("torchft.manager.ManagerClient", autospec=True)
+    def test_start_quorum_without_state_dict_callbacks(
+        self, client_mock: MagicMock
+    ) -> None:
+        manager = self._create_manager(use_async_quorum=True, init_sync=False)
+        manager._load_state_dict_fns.clear()
+        manager._user_state_dicts.clear()
+        quorum_future = MagicMock()
+
+        with patch.object(manager._executor, "submit", return_value=quorum_future):
+            manager.start_quorum()
+
+        self.assertIsNone(manager._staged_user_state_dict)
+        quorum_future.result.assert_not_called()
 
     @patch("torchft.manager.ManagerClient", autospec=True)
     def test_quorum_checkpoint_errors(self, client_mock: MagicMock) -> None:
@@ -829,6 +966,28 @@ class TestManager(TestCase):
         self.assertTrue(manager._is_state_dict_read_allowed)
         self.assertFalse(manager._state_dict_lock.w_locked())
 
+    @patch("torchft.manager.synchronize", autospec=True)
+    @patch("torchft.manager.torch.accelerator.is_available", return_value=True)
+    @patch("torchft.manager.ManagerClient", autospec=True)
+    def test_allow_state_dict_read_synchronizes_accelerator(
+        self,
+        client_mock: MagicMock,
+        is_available_mock: MagicMock,
+        synchronize_mock: MagicMock,
+    ) -> None:
+        manager = self._create_manager()
+        manager.disallow_state_dict_read()
+
+        manager.allow_state_dict_read()
+
+        synchronize_mock.assert_called_once_with()
+        self.assertTrue(manager._is_state_dict_read_allowed)
+        self.assertFalse(manager._state_dict_lock.w_locked())
+
+        # Calling allow_state_dict_read again should be a no-op.
+        manager.allow_state_dict_read()
+        synchronize_mock.assert_called_once_with()
+
     @patch("torchft.manager.ManagerClient", autospec=True)
     def test_state_dict_lock_concurrent_access(self, client_mock: MagicMock) -> None:
         """Test that _state_dict_lock properly protects concurrent access to the state dictionary."""
@@ -912,3 +1071,21 @@ class TestManager(TestCase):
 
         # Restore the original lock
         manager._state_dict_lock = original_lock
+
+    @patch("torchft.manager.ManagerClient", autospec=True)
+    def test_manager_staged_state_dict_bypasses_read_lock(
+        self, client_mock: MagicMock
+    ) -> None:
+        """A staged snapshot remains readable while a training step is active."""
+        manager = self._create_manager()
+        staged = {"model": {"weight": torch.tensor([1.0])}}
+        manager._staged_user_state_dict = staged
+        manager._state_dicts_on_training_thread.add("default")
+
+        mock_lock = create_autospec(RWLock)
+        manager._state_dict_lock = mock_lock
+
+        result = manager._manager_state_dict()
+
+        self.assertIs(result["user"]["model"], staged["model"])
+        mock_lock.r_lock.assert_not_called()

--- a/torchft/optim.py
+++ b/torchft/optim.py
@@ -47,11 +47,13 @@ class OptimizerWrapper(Optimizer):
 
     def zero_grad(self, set_to_none: bool = True) -> None:
         self.manager.start_quorum()
+        self.manager.disallow_state_dict_read()
         self.optim.zero_grad(set_to_none)
 
     # pyrefly: ignore [bad-override]
     def step(self, closure: Optional[object] = None) -> None:
         assert closure is None, "optimizers that use closures are not supported"
+        self.manager.allow_state_dict_read()
         if self.manager.should_commit():
             self.optim.step()
 

--- a/torchft/optim_test.py
+++ b/torchft/optim_test.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from unittest import TestCase
-from unittest.mock import create_autospec, MagicMock
+from unittest.mock import call, create_autospec, MagicMock
 
 import torch
 from torch.nn import Linear
@@ -32,13 +32,21 @@ class TestOptim(TestCase):
         optim.load_state_dict(optim.state_dict())
 
         optim.zero_grad()
-        self.assertEqual(manager.start_quorum.call_count, 1)
+        self.assertEqual(
+            manager.method_calls,
+            [call.start_quorum(), call.disallow_state_dict_read()],
+        )
 
         b = torch.rand(3)
         m(b).sum().backward()
 
         manager.should_commit.return_value = True
+        manager.reset_mock()
         optim.step()
+        self.assertEqual(
+            manager.method_calls,
+            [call.allow_state_dict_read(), call.should_commit()],
+        )
         manager.should_commit.return_value = False
         optim.step()
         self.assertEqual(len(optim.param_groups), 2)
@@ -47,3 +55,4 @@ class TestOptim(TestCase):
         self.assertEqual(len(optim.state), len(list(m.parameters())))
 
         self.assertEqual(manager.should_commit.call_count, 2)
+        self.assertEqual(manager.allow_state_dict_read.call_count, 2)

--- a/torchft/utils.py
+++ b/torchft/utils.py
@@ -9,19 +9,19 @@ Utility functions for TorchFT.
 """
 
 from contextlib import nullcontext
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import torch
 
 
 def get_stream_context(
     stream: Optional[torch.Stream],
-) -> Union[torch.cuda.StreamContext, torch.xpu.StreamContext, nullcontext[None]]:
+) -> Any:
     """
     Get the appropriate stream context for the given stream.
 
-    This function provides a unified way to handle stream contexts across different
-    accelerator types (CUDA, XPU).
+    This function provides a unified way to handle stream contexts across
+    accelerator types.
 
     Args:
         stream: The stream to create a context for. If None, returns nullcontext.
@@ -30,38 +30,41 @@ def get_stream_context(
         The appropriate stream context for the accelerator type, or nullcontext
         if stream is None or no accelerator is available.
     """
-    if stream is not None:
-        if torch.cuda.is_available():
-            # pyre-fixme[6]: Expected `Optional[streams.Stream]` but got `_C.Stream`
-            return torch.cuda.stream(stream)
-        elif torch.xpu.is_available():
-            # pyre-fixme[6]: Expected `Optional[streams.Stream]` but got `_C.Stream`
-            return torch.xpu.stream(stream)
-        else:
-            return nullcontext()
-    else:
+    if stream is None or not torch.accelerator.is_available():
         return nullcontext()
+
+    accelerator = torch.accelerator.current_accelerator().type
+    accelerator_module = getattr(torch, accelerator, None)
+    if accelerator_module is None or not hasattr(accelerator_module, "stream"):
+        return nullcontext()
+    return accelerator_module.stream(stream)
 
 
 def record_event() -> None:
     """
     Record an event in the current stream.
 
-    This function provides a unified way to record events across different
-    accelerator types (CUDA, XPU).
+    This function provides a unified way to record events across accelerator
+    types.
     """
-    if torch.xpu.is_available():
-        torch.xpu.current_stream().record_event(torch.xpu.Event())
-    else:
-        torch.cuda.current_stream().record_event(torch.cuda.Event(interprocess=True))
+    if not torch.accelerator.is_available():
+        return
+
+    accelerator = torch.accelerator.current_accelerator().type
+    accelerator_module = getattr(torch, accelerator)
+    event = (
+        accelerator_module.Event(interprocess=True)
+        if accelerator == "cuda"
+        else accelerator_module.Event()
+    )
+    accelerator_module.current_stream().record_event(event)
 
 
 def synchronize() -> None:
     """
-    This function provides a unified way to synchronize current stream across different
-    accelerator types (CUDA, XPU).
+    This function provides a unified way to synchronize the current stream
+    across accelerator types.
     """
-    if torch.cuda.is_available():
-        torch.cuda.current_stream().synchronize()
-    elif torch.xpu.is_available():
-        torch.xpu.current_stream().synchronize()
+    if torch.accelerator.is_available():
+        accelerator = torch.accelerator.current_accelerator().type
+        getattr(torch, accelerator).current_stream().synchronize()


### PR DESCRIPTION
## Summary

- allow selected state-dict callbacks to run on the training thread
- add first-quorum ordering so recovery state is sourced consistently
- make FSDP peer healing safe from out-of-phase replica-local collectives

Closes #343

## Related work

Draft PR #112 addresses one part of this problem: it waits for the first quorum
before forward can run. This PR has the same ordering requirement when
`init_sync=True`; unlike #112, it preserves asynchronous startup when
`init_sync=False`.

The remaining changes in this PR are FSDP-specific and are not covered by #112:

- synchronize replica-local process-group setup before checkpoint transfer;
- assign all local ranks of a recovering replica to the same source replica;
- materialize collective FSDP state on the training thread; and
- isolate state reads from optimizer updates and queued device work.

If #112 lands first, this PR can rebase on it and remove the overlapping
first-quorum wait after the unconditional versus `init_sync`-gated behavior is
resolved. The FSDP recovery changes above remain necessary independently.

## Dependencies

- Requires #344 for the accelerator-neutral stream and synchronization helpers
  used by the recovery path.
- Draft PR #112 overlaps only with the first-quorum wait and is related work,
  not a prerequisite. If it lands first, this PR can rebase and remove the
  overlapping wait after the startup policy is resolved.

## Testing

```text
python -m pytest -q \
  torchft/manager_test.py \
  torchft/optim_test.py \
  torchft/checkpointing/http_transport_test.py
40 passed, 1 skipped

cargo test test_compute_quorum_results
4 passed
```

