### PR TITLE
Fix Pyre for updated c10d types

### DIFF
--- a/torchft/process_group.py
+++ b/torchft/process_group.py
@@ -352,11 +352,14 @@ class ProcessGroup(BaseProcessGroup):
 
         group_name = self._register(name)
 
-        return dist.new_group(
-            ranks=[dist.get_rank()],
-            backend=group_name,
-            group_desc=group_name,
-            timeout=timedelta(seconds=60.0),  # this timeout isn't used
+        return cast(
+            ProcessGroup,
+            dist.new_group(
+                ranks=[dist.get_rank()],
+                backend=group_name,
+                group_desc=group_name,
+                timeout=timedelta(seconds=60.0),  # this timeout isn't used
+            ),
         )
 
     @property

--- a/torchft/quantization.py
+++ b/torchft/quantization.py
@@ -651,7 +651,7 @@ def fused_reduce_fp8(
     output: torch.Tensor,
     all_reduce_group_size: int,
     all_reduce_rank: int,
-    reduce_op: ReduceOp = ReduceOp.SUM,
+    reduce_op: ReduceOp | ReduceOp.RedOpType = ReduceOp.SUM,
 ) -> None:
     """
     Reduces rows of the output tensor for the given rank. The output tensor

--- a/torchft/torchcomms.py
+++ b/torchft/torchcomms.py
@@ -83,7 +83,7 @@ class _TorchCommsWork(Work):
         return self._work.is_completed()
 
 
-_REDUCE_OP_MAP: dict[ReduceOp, object] = {
+_REDUCE_OP_MAP: dict[ReduceOp | ReduceOp.RedOpType, object] = {
     ReduceOp.SUM: torchcomms.ReduceOp.SUM,
     ReduceOp.PRODUCT: torchcomms.ReduceOp.PRODUCT,
     ReduceOp.MIN: torchcomms.ReduceOp.MIN,


### PR DESCRIPTION
PyTorch nightly widened c10d reduction and process-group return types, causing four Pyre errors. Accept both reduction representations and narrow the registered singleton group.

Test plan: `uv pip install -e . --no-deps`; `lintrunner --skip PYRE,FLAKE --force-color --all-files`; `pyre check`; `cargo +nightly fmt --check`; `pytest -v --reruns 3 --reruns-delay 5`; `cargo test -v`