### PR TITLE
Remove Pyre mode headers in 449 fbcode directories

### DIFF
--- a/torchft/quantization.py
+++ b/torchft/quantization.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-unsafe
 import torch
 
 # pyre-ignore[21]: Could not find a module corresponding to import `triton`


### PR DESCRIPTION
Summary:
Remove standalone `# pyre-strict` and `# pyre-unsafe` mode headers from 587 Python files across 449 fbcode directories.

Pyrefly type-checks all files in one consistent mode, so these legacy per-file mode headers no longer have an effect. Other Pyre directives and generated files are left unchanged.

Pyrefly is now the default type checker across FBCode so this diff introduces no functional changes.

drop-conflicts
#pyreupgrade

Reviewed By: maggiemoss

Differential Revision: D117751289


