### PR TITLE
Release torchft 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torchft"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Easy Per Step Fault Tolerance for PyTorch
   |
 </p>
 <p align="center">
-  <a href="https://pypi.org/project/torchft-nightly/"><img alt="PyPI - Version" src="https://img.shields.io/pypi/v/torchft-nightly"></a>
+  <a href="https://pypi.org/project/torchft/"><img alt="PyPI - Stable Version" src="https://img.shields.io/pypi/v/torchft"></a>
+  <a href="https://pypi.org/project/torchft-nightly/"><img alt="PyPI - Nightly Version" src="https://img.shields.io/pypi/v/torchft-nightly"></a>
 </p>
 
 ---
@@ -113,9 +114,15 @@ See the design doc linked above for more details.
 
 ## Installing from PyPI
 
-We have nighty builds available at https://pypi.org/project/torchft-nightly/
+Install the latest stable release:
 
-To install torchft with minimal dependencies you can run:
+```sh
+pip install torchft
+```
+
+Nightly builds are available at https://pypi.org/project/torchft-nightly/
+
+To install a nightly build:
 
 ```sh
 pip install torchft-nightly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "torchft"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
The stable package has not been released since 0.1.1. Set version 0.2.0, align Python support with current dependencies, and document stable installation.

Test plan:

- `cargo test -v`
- `cargo +nightly fmt --check`
- `pytest -v --reruns 3 --reruns-delay 5`
- `lintrunner Cargo.toml README.md pyproject.toml`
- Build and `twine check` CPython 3.9–3.13 wheels and sdist

The full CI lint job has the same 39 pre-existing Pyre errors as `main`: https://github.com/meta-pytorch/torchft/actions/runs/33120218269
