### PR TITLE
Restore Pyre mode header

### DIFF
--- a/torchft/quantization.py
+++ b/torchft/quantization.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+# pyre-unsafe
 import torch
 
 # pyre-ignore[21]: Could not find a module corresponding to import `triton`


### PR DESCRIPTION
Summary: Revert the TorchFT portion of D117751289 by restoring the `# pyre-unsafe` header in `torchft/quantization.py`.

Differential Revision: D117785789


