### PR TITLE
Fix managed-future callback late binding and record_event return value

### DIFF
--- a/torchft/manager.py
+++ b/torchft/manager.py
@@ -1280,17 +1280,21 @@ class _ManagedWork(dist._Work):
         is_future_wrapped = False
         while managed_fut._next:
 
+            # Bind the node as a default argument: the loop rebinds `managed_fut`,
+            # so a callback that runs after the loop (e.g. when the future completes
+            # on another thread) would otherwise see the tail node instead.
             def callback(
                 fut: torch.futures.Future[object],
+                node: _ManagedFuture[object] = managed_fut,
             ) -> object:
-                nonlocal managed_fut, value
+                nonlocal value
                 # change the stream to avoid making the callback stream
                 # dependent on process group stream running the allreduce
                 with get_stream_context(self._stream):
                     # Setup stream dependency
                     fut.wait()
-                    assert managed_fut._callback
-                    value = managed_fut._callback(
+                    assert node._callback
+                    value = node._callback(
                         _SimpleFuture(value),
                     )
                     return value

--- a/torchft/manager_test.py
+++ b/torchft/manager_test.py
@@ -13,11 +13,18 @@ from unittest import TestCase
 from unittest.mock import create_autospec, MagicMock, patch
 
 import torch
+import torch.distributed as dist
 from torch.distributed import ReduceOp, TCPStore
 from torchft._torchft import QuorumResult
 from torchft.checkpointing._rwlock import RWLock
 from torchft.checkpointing.transport import CheckpointTransport
-from torchft.manager import Manager, MANAGER_ADDR_KEY, REPLICA_ID_KEY, WorldSizeMode
+from torchft.manager import (
+    _ManagedWork,
+    Manager,
+    MANAGER_ADDR_KEY,
+    REPLICA_ID_KEY,
+    WorldSizeMode,
+)
 from torchft.process_group import ProcessGroup
 from torchft.work import _DummyWork
 
@@ -912,3 +919,85 @@ class TestManager(TestCase):
 
         # Restore the original lock
         manager._state_dict_lock = original_lock
+
+
+class TestManagedWork(TestCase):
+    """`_ManagedWork`'s callback chain when the underlying future completes only
+    after the chain is built, e.g. from another thread as ProcessGroupBabyNCCL does."""
+
+    class _PendingWork(dist._Work):
+        """A `Work` whose future nobody has completed yet."""
+
+        def __init__(self, fut: torch.futures.Future[object]) -> None:
+            super().__init__()
+            self._fut = fut
+
+        def wait(self, timeout: Optional[timedelta] = None) -> bool:
+            return True
+
+        def block_current_stream(self, timeout: Optional[timedelta] = None) -> None:
+            return None
+
+        def synchronize(self) -> None:
+            return None
+
+        def get_future(self) -> torch.futures.Future[object]:
+            return self._fut
+
+    def _manager(self) -> MagicMock:
+        manager = create_autospec(Manager)
+        # pass futures through unchanged so callback errors surface in the test
+        manager.wrap_future = lambda fut, default, timeout=None: fut
+        return manager
+
+    def test_callback_runs_when_the_future_completes_after_the_chain_is_built(
+        self,
+    ) -> None:
+        """Regression test: callbacks used to read the loop variable and hit the
+        tail node, whose `_callback` is None."""
+        pending: torch.futures.Future[object] = torch.futures.Future()
+        work = _ManagedWork(self._manager(), self._PendingWork(pending), "initial")
+
+        ran: list[object] = []
+
+        def callback(fut: torch.futures.Future[object]) -> object:
+            ran.append(fut.value())
+            return "reduced"
+
+        tail = work.get_future().then(callback)
+
+        # builds the chain; `pending` is not complete so nothing can have run yet
+        work.block_current_stream()
+        self.assertEqual(ran, [])
+
+        completer = threading.Thread(
+            target=lambda: pending.set_result("from the process group")
+        )
+        completer.start()
+        completer.join()
+
+        self.assertEqual(ran, ["initial"], "the chained callback never ran")
+        self.assertEqual(tail.wait(), "reduced")
+
+    def test_a_two_callback_chain_runs_in_order(self) -> None:
+        """Same as above, with a chain of two callbacks."""
+        pending: torch.futures.Future[object] = torch.futures.Future()
+        work = _ManagedWork(self._manager(), self._PendingWork(pending), 0)
+
+        order: list[str] = []
+
+        def first(fut: torch.futures.Future[object]) -> object:
+            order.append("first")
+            return 1
+
+        def second(fut: torch.futures.Future[object]) -> object:
+            order.append("second")
+            return 2
+
+        tail = work.get_future().then(first).then(second)
+        work.block_current_stream()
+
+        pending.set_result(None)
+
+        self.assertEqual(order, ["first", "second"])
+        self.assertEqual(tail.wait(), 2)

--- a/torchft/utils.py
+++ b/torchft/utils.py
@@ -43,17 +43,22 @@ def get_stream_context(
         return nullcontext()
 
 
-def record_event() -> None:
+def record_event() -> Union[torch.cuda.Event, torch.xpu.Event]:
     """
-    Record an event in the current stream.
+    Record an event in the current stream and return it.
 
     This function provides a unified way to record events across different
-    accelerator types (CUDA, XPU).
+    accelerator types (CUDA, XPU). Callers send the returned event to another
+    process so it can wait on this stream's work.
     """
     if torch.xpu.is_available():
-        torch.xpu.current_stream().record_event(torch.xpu.Event())
-    else:
-        torch.cuda.current_stream().record_event(torch.cuda.Event(interprocess=True))
+        xpu_event = torch.xpu.Event()
+        torch.xpu.current_stream().record_event(xpu_event)
+        return xpu_event
+
+    cuda_event = torch.cuda.Event(interprocess=True)
+    torch.cuda.current_stream().record_event(cuda_event)
+    return cuda_event
 
 
 def synchronize() -> None:

--- a/torchft/utils_test.py
+++ b/torchft/utils_test.py
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from unittest import TestCase
+
+import torch
+
+from torchft.utils import record_event
+
+
+class TestRecordEvent(TestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "needs CUDA")
+    def test_returns_the_event_it_recorded(self) -> None:
+        """Regression test: `record_event` used to return None, so the process
+        receiving the event had nothing to wait on."""
+        event = record_event()
+
+        self.assertIsNotNone(event, "record_event must return the event it recorded")
+        self.assertIsInstance(event, torch.cuda.Event)
+        # a recorded interprocess event must be able to produce an IPC handle
+        self.assertIsNotNone(event.ipc_handle())
+        event.synchronize()
+        self.assertTrue(event.query())


### PR DESCRIPTION
## What is broken

This PR fixes two bugs. Both break training when we use `ProcessGroupBabyNCCL` (the process group that runs NCCL in a child process).

**Bug 1: the callback chain reads the wrong node.**
`_ManagedWork` keeps a list of callbacks and hooks them up later, in a loop. Each callback was supposed to remember its own spot in the list. But because of how Python closures work, all callbacks shared one variable, and the loop kept moving that variable forward. When the loop was done, the variable pointed at the end of the list, which has no callback (`None`).

If the result is ready right away (like in the existing tests with `_DummyWork`), the callback runs inside the loop and sees the right spot. So nothing looked wrong. But with `ProcessGroupBabyNCCL`, the result comes later, from another thread. Then every callback saw the end of the list, hit `assert None`, and failed. So every allreduce failed and no step could finish.

**Bug 2: `record_event` threw the event away.**
`record_event()` made a CUDA event but returned nothing. All callers do `event = record_event()` and send the event to another process, which calls `event.wait()` before reading the tensor. Since the event was always `None`, the wait was skipped. The reader could read the tensor before the GPU finished writing it. This fails silently and only sometimes, when the collective is slow.

## The fix

- In `_set_future_callback`, give each callback its own copy of its list node (`node=managed_fut` as a default argument), instead of the shared variable.
- Make `record_event()` return the event it records.

## How I tested it

- New tests in `manager_test.py` build the callback chain first and complete the future from another thread, like baby NCCL does. They fail on `main` and pass with this fix.
- New test in `utils_test.py` checks `record_event()` returns a real, shareable CUDA event. It fails on `main` and passes with this fix.
- `manager_test.py` + `utils_test.py`: 26/26 pass.
- `process_group_test.py` gives the same result on this branch and on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
